### PR TITLE
Add utility class to handle different date-time formats

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -1,0 +1,107 @@
+package seedu.address.commons.util;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalQuery;
+
+/**
+ * Helper functions for handling date and date-time objects.
+ */
+public class DateTimeUtil {
+
+    // Date formats
+    /** e.g. 20200920 */
+    public static final DateTimeFormatter DATE_FORMAT_YEAR_MONTH_DAY =
+            DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    /** e.g. 20-9-2020 */
+    public static final DateTimeFormatter DATE_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED =
+            DateTimeFormatter.ofPattern("d-M-yyyy");
+
+    /** e.g. 20/9/2020 */
+    public static final DateTimeFormatter DATE_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED =
+            DateTimeFormatter.ofPattern("d/M/yyyy");
+
+
+    // Date-time formats
+    /** e.g. 20200920 or 20200920 2359 */
+    public static final DateTimeFormatter DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME =
+            createFormatterWithOptionalTime("yyyyMMdd", " HHmm");
+
+    /** e.g. 20-9-2020 (time defaults to 0000) or 20-9-2020 2359 */
+    public static final DateTimeFormatter DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME =
+            createFormatterWithOptionalTime("d-M-yyyy", " HHmm");
+
+    /** e.g. 20/9/2020 (time defaults to 0000) or 20/09/2020 2359 */
+    public static final DateTimeFormatter DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME =
+            createFormatterWithOptionalTime("d/M/yyyy", " HHmm");
+
+
+    /**
+     * Parses the text into a date-time object (e.g. {@code LocalDate} or {@code LocalDateTime})
+     * using all given {@code DateTimeFormatter} and returns the first successful result.
+     *
+     * The text is parsed using each formatter in turn. No output is generated if a formatter fails to
+     * parse the text. However, a {@code DateTimeParseException} is thrown if all formatters fail.
+     *
+     * The {@code TemporalQuery<T>} is typically a method reference to a
+     * {@code from(TemporalAccessor)} method.
+     * For example:
+     * <pre>
+     *     LocalDate date = DateTimeUtil.parseFirstMatching(text, LocalDate::from, formatter1, formatter2);
+     * </pre>
+     *
+     * For more details, refer to
+     * https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#
+     * parse-java.lang.CharSequence-java.time.temporal.TemporalQuery-
+     *
+     * @param text The text to parse, cannot be null.
+     * @param query The
+     * @param formatters Formatters to parse the text with, cannot be null.
+     * @param <T> A date-time class, usually a {@code TemporalAccessor}.
+     * @return The date-time object parsed from text.
+     * @throws DateTimeParseException if text cannot be parsed with any of the formatters or no formatters provided.
+     */
+    public static <T> T parseFirstMatching(
+            CharSequence text, TemporalQuery<T> query, DateTimeFormatter... formatters) {
+        requireAllNonNull(text, query, formatters);
+
+        for (DateTimeFormatter formatter : formatters) {
+            try {
+                return formatter.parse(text, query);
+            } catch (DateTimeParseException e) {
+                // Current formatter is invalid.
+                // Proceed to test next formatter.
+            }
+        }
+
+        String exceptionMessage = String.format("Unable to parse %s", text);
+        int errorIndex = 0; // index in parsed text that was invalid, set to 0 to indicate entirety of text
+
+        throw new DateTimeParseException(exceptionMessage, text, errorIndex);
+    }
+
+    /**
+     * Creates a {@code DateTimeFormatter} with default values of time.
+     * If a time conforms to the time format, the {@cod DateTimeFormatter} sets the parsed date-time
+     * to that value. Otherwise, the hour and minute of the parsed date-time are set to 0.
+     *
+     * @param dateFormat The pattern for the date portion of a string parsed by  a{@code DateTimeFormatter}.
+     * @param timeFormat The pattern for the time portion of a string parsed by a {@code DateTimeFormatter}.
+     * @return A {@code DateTimeFormatter} that defaults the hour and minute to 0 if time does not conform to format.
+     */
+    private static DateTimeFormatter createFormatterWithOptionalTime(String dateFormat, String timeFormat) {
+        return new DateTimeFormatterBuilder()
+                .appendPattern(dateFormat)
+                .optionalStart()
+                .appendPattern(timeFormat)
+                .optionalEnd()
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                .toFormatter();
+    }
+}

--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -60,7 +60,7 @@ public class DateTimeUtil {
      * parse-java.lang.CharSequence-java.time.temporal.TemporalQuery-
      *
      * @param text The text to parse, cannot be null.
-     * @param query The
+     * @param query A way to retrieve information from a temporal-based object.
      * @param formatters Formatters to parse the text with, cannot be null.
      * @param <T> A date-time class, usually a {@code TemporalAccessor}.
      * @return The date-time object parsed from text.

--- a/src/test/java/seedu/address/commons/util/DateTimeUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/DateTimeUtilTest.java
@@ -1,0 +1,246 @@
+package seedu.address.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import org.junit.jupiter.api.Test;
+
+public class DateTimeUtilTest {
+
+    @Test
+    public void parseFirstMatching_nullText_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> DateTimeUtil.parseFirstMatching(
+                null, LocalDate::from, DateTimeFormatter.ofPattern("yyyyMMdd")));
+    }
+
+    @Test
+    public void parseFirstMatching_nullQuery_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> DateTimeUtil.parseFirstMatching(
+                "20201230", null, DateTimeFormatter.ofPattern("yyyyMMdd")));
+    }
+
+    @Test
+    public void parseFirstMatching_nullFormatter_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> DateTimeUtil.parseFirstMatching(
+                "20201230", LocalDate::from, (DateTimeFormatter) null));
+    }
+
+    @Test
+    public void parseFirstMatching_noFormattersGiven_throwsDateTimeParseException() {
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "20201230", LocalDate::from));
+    }
+
+    @Test
+    public void parseFirstMatching_singleDateFormatterInvalidText_throwsDateTimeParseException() {
+        // EP: invalid text for DATE_FORMAT_YEAR_MONTH_DAY
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30122020", LocalDate::from, DateTimeUtil.DATE_FORMAT_YEAR_MONTH_DAY));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30-12-2020", LocalDate::from, DateTimeUtil.DATE_FORMAT_YEAR_MONTH_DAY));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30/12/2020", LocalDate::from, DateTimeUtil.DATE_FORMAT_YEAR_MONTH_DAY));
+
+        // EP: invalid text for DATE_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "20201230", LocalDate::from, DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "2020-12-30", LocalDate::from, DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30/12/2020", LocalDate::from, DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED));
+
+        // EP: invalid text for DATE_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "20201230", LocalDate::from, DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30-12-2020", LocalDate::from, DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "2020/12/30", LocalDate::from, DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED));
+    }
+
+    @Test
+    public void parseFirstMatching_singleDateTimeFormatterInvalidText_throwsDateTimeParseException() {
+        // EP: invalid text for DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30122020 2359", LocalDateTime::from, DateTimeUtil.DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "2020-12-30 2359", LocalDateTime::from, DateTimeUtil.DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30/12/2020 2359", LocalDateTime::from, DateTimeUtil.DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME));
+
+        // EP: invalid text for DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "20201230 2359", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "2020-12-30 2359", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30/12/2020 2359", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME));
+
+        // EP: invalid text for DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "20201230 2359", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30-12-2020", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "2020/12/30", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME));
+    }
+
+    @Test
+    public void parseFirstMatching_manyDateFormattersInvalidText_throwsDateTimeParseException() {
+        DateTimeFormatter[] formatters = {
+            DateTimeUtil.DATE_FORMAT_YEAR_MONTH_DAY,
+            DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED,
+            DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED
+        };
+
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30122020", LocalDate::from, formatters));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "aaa", LocalDate::from, formatters));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "", LocalDate::from, formatters));
+    }
+
+    @Test
+    public void parseFirstMatching_manyDateTimeFormattersInvalidText_throwsDateTimeParseException() {
+        DateTimeFormatter[] formatters = {
+            DateTimeUtil.DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME,
+            DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME,
+            DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME
+        };
+
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "30122020 2359", LocalDateTime::from, formatters));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "aaa", LocalDateTime::from, formatters));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.parseFirstMatching(
+                "", LocalDateTime::from, formatters));
+    }
+
+    @Test
+    public void parseFirstMatching_singleDateFormatterValidText_correctObject() {
+        int year = 2020;
+        int month = 12;
+        int day = 30;
+        LocalDate date = LocalDate.of(year, month, day);
+
+        assertEquals(date, DateTimeUtil.parseFirstMatching(
+                "20201230", LocalDate::from, DateTimeUtil.DATE_FORMAT_YEAR_MONTH_DAY));
+        assertEquals(date, DateTimeUtil.parseFirstMatching(
+                "30-12-2020", LocalDate::from, DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED));
+        assertEquals(date, DateTimeUtil.parseFirstMatching(
+                "30/12/2020", LocalDate::from, DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED));
+    }
+
+    @Test
+    public void parseFirstMatching_singleDateTimeFormatterValidText_correctObject() {
+        int year = 2020;
+        int month = 12;
+        int day = 30;
+        int hour = 23;
+        int minute = 59;
+        LocalDateTime dateTime = LocalDateTime.of(year, month, day, hour, minute);
+
+        /*
+         * EP: Valid text (custom time)
+         */
+        assertEquals(dateTime, DateTimeUtil.parseFirstMatching(
+                "20201230 2359", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME));
+        assertEquals(dateTime, DateTimeUtil.parseFirstMatching(
+                "30-12-2020 2359", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME));
+        assertEquals(dateTime, DateTimeUtil.parseFirstMatching(
+                "30/12/2020 2359", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME));
+
+        int defaultHour = 0;
+        int defaultMinute = 0;
+        LocalDateTime dateWithDefaultTime = LocalDateTime.of(year, month, day, defaultHour, defaultMinute);
+
+        /*
+         * EP: Valid text (default time)
+         */
+        assertEquals(dateWithDefaultTime, DateTimeUtil.parseFirstMatching(
+                "20201230", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME));
+        assertEquals(dateWithDefaultTime, DateTimeUtil.parseFirstMatching(
+                "30-12-2020", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME));
+        assertEquals(dateWithDefaultTime, DateTimeUtil.parseFirstMatching(
+                "30/12/2020", LocalDateTime::from,
+                DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME));
+    }
+
+    @Test
+    public void parseFirstMatching_manyDateFormatterValidText_correctObject() {
+        DateTimeFormatter[] formatters = {
+            DateTimeUtil.DATE_FORMAT_YEAR_MONTH_DAY,
+            DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED,
+            DateTimeUtil.DATE_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED
+        };
+
+        int year = 2020;
+        int month = 12;
+        int day = 30;
+
+        LocalDate date = LocalDate.of(year, month, day);
+        assertEquals(date, DateTimeUtil.parseFirstMatching(
+                "20201230", LocalDate::from, formatters));
+        assertEquals(date, DateTimeUtil.parseFirstMatching(
+                "30-12-2020", LocalDate::from, formatters));
+        assertEquals(date, DateTimeUtil.parseFirstMatching(
+                "30/12/2020", LocalDate::from, formatters));
+    }
+
+    @Test
+    public void parseFirstMatching_manyDateTimeFormatterValidText_correctObject() {
+        DateTimeFormatter[] formatters = {
+            DateTimeUtil.DATETIME_FORMAT_YEAR_MONTH_DAY_OPTIONAL_TIME,
+            DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_HYPHEN_DELIMITED_OPTIONAL_TIME,
+            DateTimeUtil.DATETIME_FORMAT_DAY_MONTH_YEAR_SLASH_DELIMITED_OPTIONAL_TIME
+        };
+
+        int year = 2020;
+        int month = 12;
+        int day = 30;
+        int hour = 23;
+        int minute = 59;
+        LocalDateTime dateWithCustomTime = LocalDateTime.of(year, month, day, hour, minute);
+
+        /*
+         * EP: Valid text (custom time)
+         */
+        assertEquals(dateWithCustomTime, DateTimeUtil.parseFirstMatching(
+                "20201230 2359", LocalDateTime::from, formatters));
+        assertEquals(dateWithCustomTime, DateTimeUtil.parseFirstMatching(
+                "30-12-2020 2359", LocalDateTime::from, formatters));
+        assertEquals(dateWithCustomTime, DateTimeUtil.parseFirstMatching(
+                "30/12/2020 2359", LocalDateTime::from, formatters));
+
+        int defaultHour = 0;
+        int defaultMinute = 0;
+        LocalDateTime dateWithDefaultTime = LocalDateTime.of(year, month, day, defaultHour, defaultMinute);
+
+        /*
+         * EP: Valid text (default time)
+         */
+        assertEquals(dateWithDefaultTime, DateTimeUtil.parseFirstMatching(
+                "20201230", LocalDateTime::from, formatters));
+        assertEquals(dateWithDefaultTime, DateTimeUtil.parseFirstMatching(
+                "30-12-2020", LocalDateTime::from, formatters));
+        assertEquals(dateWithDefaultTime, DateTimeUtil.parseFirstMatching(
+                "30/12/2020", LocalDateTime::from, formatters));
+    }
+}


### PR DESCRIPTION
The current implementation does not have an abstraction to manage date-time objects.

Let's add a utility class to manage the common types of date formats. Examples include:
- `yyyyMMdd` ("20200924") 
- `dd-M-yyyy` ("24-9-2020")
- `dd/M/yyyy` ("24/9/2020")