### PR TITLE
Add deletepatient Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -10,12 +10,13 @@ title: User Guide
 3. [Features](#3-features)<br>
     3.1 [Command Format](#31-command-format)<br>
     3.2 [Add a patient: `addpatient`](#32-add-a-patient-addpatient)<br>
-    3.3 [Edit a patient: `editpatient`](#33-edit-a-patient-editpatient)<br>
-    3.4 [Search information: `searchpatient`](#34-search-information-searchpatient)<br>
-    3.5 [Add rooms in hotel: `addRooms`](#35-add-rooms-in-hotel-addrooms)<br>
-    3.6 [Find the first free room: `findRoom`](#36-find-the-first-free-room-findroom)<br>
-    3.7 [View help: `help`](#37-view-help-help)<br>
-    3.8 [Save the data](#38-save-the-data)<br>
+    3.3 [Delete a patient: `deletepatient`](#33-delete-a-patient-deletepatient)<br>
+    3.4 [Edit a patient: `editpatient`](#34-edit-a-patient-editpatient)<br>
+    3.5 [Search information: `searchpatient`](#35-search-information-searchpatient)<br>
+    3.6 [Add rooms in hotel: `addRooms`](#36-add-rooms-in-hotel-addrooms)<br>
+    3.7 [Find the first free room: `findRoom`](#37-find-the-first-free-room-findroom)<br>
+    3.8 [View help: `help`](#38-view-help-help)<br>
+    3.9 [Save the data](#39-save-the-data)<br>
  4. [FAQ](#4-faq)
  5. [Command Summary](#5-command-summary)
 
@@ -69,7 +70,6 @@ Covigent is a desktop app for managing information of quarantined individuals an
 
 ### 3.2 Add a patient: `addpatient`
 
-
 Adds a quarantined individual to the application.
 
 Format: `addpatient n/NAME t/TEMPERATURE d/PERIOD_OF_STAY p/PHONE_NUMBER a/AGE [c/COMMENT]`
@@ -83,13 +83,26 @@ Examples:
 * `addpatient n/John Doe p/98765432 t/37.4 d/20200910-20200924 a/35`
 * `addpatient n/Betsy Crowe t/36.5 d/20201001-20201014 p/91234567 a/19 c/Is asthmatic`
 
-### 3.3 Edit a patient: `editpatient`
+### 3.3 Delete a patient: `deletepatient`
+
+Deletes an existing patient in the application.
+
+Format: `deletepatient NAME`
+
+* Deletes the patient with the specified `NAME`. The name refers to the name of the patient inputted into the application earlier. The name **must match exactly with the name of the patient**.
+* `NAME` is case-insensitive.
+
+Example:
+* `deletepatient Mary Doe` Deletes the patient record of Mary Doe from the application.
+
+
+### 3.4 Edit a patient: `editpatient`
 
 Edits an existing patient in the application.
 
 Format: `editpatient NAME [n/NAME] [t/TEMPERATURE] [d/PERIOD_OF_STAY] [p/PHONE_NUMBER] [a/AGE] [c/COMMENT]`
 
-* Edits the patient with the specified `NAME`. The name refers to the name of the patient inputted into the application eariler. The name **must match exactly with the name of the patient**.
+* Edits the patient with the specified `NAME`. The name refers to the name of the patient inputted into the application earlier. The name **must match exactly with the name of the patient**.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * `NAME` is case-insensitive.
@@ -100,7 +113,7 @@ Examples:
 *  `editpatient john doe p/91234567` Edits the phone number of john doe to be `91234567`.
 *  `editpatient alex t/36.7 a/21 d/20200303-20200315` Edits the temperature, age and period of stay of alex to be `36.7`, `21` and `20200303-20200315` respectively.
 
-### 3.4 Search information: `searchpatient`
+### 3.5 Search information: `searchpatient`
 
 Searches the patients that matches the given criteria in the application.
 
@@ -113,7 +126,7 @@ Examples:
 *  `searchpatient n/john` Searches patients with a name John.
 *  `searchpatient tr/36.5-36.7` Searches patients with temperature 36.5 to 36.7 degree, celsius, both inclusive. 
 
-### 3.5 Add rooms in quarantine facility: `addRooms`
+### 3.6 Add rooms in quarantine facility: `addRooms`
 
 Adds the number of rooms in the quarantine facility to the app.
 
@@ -125,7 +138,7 @@ Examples:
 * `addRooms 123`
 * `addRooms 400`
 
-### 3.6 Find the first free room: `findRoom`
+### 3.7 Find the first free room: `findRoom`
 
 Finds the room with the lowest room number that is free for use.
 
@@ -133,13 +146,13 @@ Format: `findRoom`
 
 * Finds the room number of least value that can be safely used for accommodation
 
-### 3.7 View help: `help`
+### 3.8 View help: `help`
 
 Shows a message explaining how to access the help page.
 
 Format: `help`
 
-### 3.8 Save the data
+### 3.9 Save the data
 
 Covigent data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,7 +7,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX = "The patient name provided is invalid";
+    public static final String MESSAGE_INVALID_PATIENT_NAME_INPUT = "The patient name provided "
+            + "cannot be found in Covigent.";
     public static final String MESSAGE_PATIENT_LISTED_OVERVIEW = "%1$d patient listed!";
     public static final String MESSAGE_TOO_MANY_COMMANDS = "Too many commands entered!";
     public static final String NO_ARGUMENTS_GIVEN = "no arguments are given";

--- a/src/main/java/seedu/address/logic/commands/patient/AddPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/AddPatientCommand.java
@@ -22,13 +22,13 @@ public class AddPatientCommand extends Command {
     public static final String COMMAND_WORD = "addpatient";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a patient to Covigent. "
-            + "Parameters: "
+            + "\nParameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_TEMP + "TEMPERATURE "
             + PREFIX_PERIOD_OF_STAY + "PERIOD OF STAY "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_AGE + "AGE "
-            + "[" + PREFIX_COMMENTS + "COMMENTS]...\n"
+            + "[" + PREFIX_COMMENTS + "COMMENTS]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_TEMP + "37.0 "
@@ -38,7 +38,7 @@ public class AddPatientCommand extends Command {
             + PREFIX_COMMENTS + "Vegan,asthmatic ";
 
     public static final String MESSAGE_SUCCESS = "New patient added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in Covigent";
+    public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in Covigent.";
 
     private final Patient toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/patient/DeletePatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/DeletePatientCommand.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -13,23 +12,27 @@ import seedu.address.model.Model;
 import seedu.address.model.patient.Patient;
 
 /**
- * Deletes a patient identified using it's displayed index from the address book.
+ * Deletes a patient identified by the patient's name from the application.
  */
 public class DeletePatientCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD = "deletepatient";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the patient identified by the index number used in the displayed patient list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the patient identified by the patient's name used in the displayed patient list.\n"
+            + "Parameters: NAME (must match exactly with the name of the patient to be deleted from the patient list)\n"
+            + "Example: " + COMMAND_WORD + " Mary Doe";
 
     public static final String MESSAGE_DELETE_PATIENT_SUCCESS = "Deleted Patient: %1$s";
 
-    private final Index targetIndex;
+    private final String nameOfPatientToDelete;
 
-    public DeletePatientCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    /**
+     * Creates a DeleteCommand to delete the patient with the name {@code String}.
+     * @param nameOfPatientToDelete name in the filtered patient list to be deleted
+     */
+    public DeletePatientCommand(String nameOfPatientToDelete) {
+        this.nameOfPatientToDelete = nameOfPatientToDelete.trim().toLowerCase();
     }
 
     @Override
@@ -37,19 +40,21 @@ public class DeletePatientCommand extends Command {
         requireNonNull(model);
         List<Patient> lastShownList = model.getFilteredPatientList();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
+        for (int i = 0; i < lastShownList.size(); i++) {
+            String patientName = lastShownList.get(i).getName().toString();
+            if (patientName.trim().toLowerCase().equals(nameOfPatientToDelete)) {
+                Patient patientToDelete = lastShownList.get(i);
+                model.deletePatient(patientToDelete);
+                return new CommandResult(String.format(MESSAGE_DELETE_PATIENT_SUCCESS, patientToDelete));
+            }
         }
-
-        Patient patientToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deletePatient(patientToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PATIENT_SUCCESS, patientToDelete));
+        throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_NAME_INPUT);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeletePatientCommand // instanceof handles nulls
-                && targetIndex.equals(((DeletePatientCommand) other).targetIndex)); // state check
+                && nameOfPatientToDelete.equals(((DeletePatientCommand) other).nameOfPatientToDelete)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/patient/EditPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/EditPatientCommand.java
@@ -28,7 +28,7 @@ import seedu.address.model.patient.Phone;
 import seedu.address.model.patient.Temperature;
 
 /**
- * Edits a patient in address book with the selected name.
+ * Edits a patient in the app with the selected name.
  * Input of name is case insensitive.
  */
 public class EditPatientCommand extends Command {
@@ -88,7 +88,7 @@ public class EditPatientCommand extends Command {
         }
 
         if (index.getZeroBased() == 0) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_NAME_INPUT);
         }
 
         Patient patientToEdit = lastShownList.get(index.getZeroBased() - 1);

--- a/src/main/java/seedu/address/logic/commands/patient/EditPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/EditPatientCommand.java
@@ -45,13 +45,13 @@ public class EditPatientCommand extends Command {
             + "[" + PREFIX_AGE + "AGE] "
             + "[" + PREFIX_PERIOD_OF_STAY + "PERIOD OF STAY] "
             + "[" + PREFIX_COMMENTS + "COMMENT] "
-            + "Example: " + COMMAND_WORD + " john "
+            + "\nExample: " + COMMAND_WORD + " john "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_TEMP + "36.5";
 
     public static final String MESSAGE_EDIT_PATIENT_SUCCESS = "Edited Patient: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in Covigent.";
 
     private final String patientToBeEdited;
     private final EditPatientDescriptor editPatientDescriptor;

--- a/src/main/java/seedu/address/logic/commands/patient/SearchPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/SearchPatientCommand.java
@@ -28,7 +28,7 @@ public class SearchPatientCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Searches a patient or a list of patients with only one specific criteria. "
             + "\nParameters: "
-            + PREFIX_NAME + "NAME || "
+            + PREFIX_NAME + "NAME or "
             + PREFIX_TEMP_RANGE + "TEMPERATURE RANGE "
             + "\nExample: " + COMMAND_WORD + " "
             + PREFIX_TEMP_RANGE + "36.1-37.9 ";

--- a/src/main/java/seedu/address/logic/commands/patient/SearchPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/SearchPatientCommand.java
@@ -19,24 +19,24 @@ import seedu.address.model.patient.TemperatureRange;
 
 
 /**
- * Search a patient or a list of patient according to a name or a range of temperature.
+ * Searches a patient or a list of patient according to a name or a range of temperature.
  */
 public class SearchPatientCommand extends Command {
 
     public static final String COMMAND_WORD = "searchpatient";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Search a patient or a list of patients with only one specific criteria in Covigent. "
-            + "Parameters: "
+            + ": Searches a patient or a list of patients with only one specific criteria. "
+            + "\nParameters: "
             + PREFIX_NAME + "NAME || "
             + PREFIX_TEMP_RANGE + "TEMPERATURE RANGE "
-            + "Example: " + COMMAND_WORD + " "
+            + "\nExample: " + COMMAND_WORD + " "
             + PREFIX_TEMP_RANGE + "36.1-37.9 ";
 
     public static final String MESSAGE_SEARCH_PATIENT_SUCCESS = "Patient(s) found: %1$s";
     public static final String MESSAGE_NOT_FOUND = "At least one field to edit must be provided.";
     public static final String MESSAGE_PATIENT_NOT_FOUND = "The patient you entered is not in the list.";
-    public static final String MESSAGE_SEARCH_PATIENT_LIST_SUCCESS = "Patient match your criteria found: \n";
+    public static final String MESSAGE_SEARCH_PATIENT_LIST_SUCCESS = "Patient(s) matching your criteria found: \n";
 
     private final SearchPatientDescriptor searchPatientDescriptor;
 

--- a/src/main/java/seedu/address/logic/parser/patient/DeletePatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/patient/DeletePatientCommandParser.java
@@ -2,14 +2,12 @@ package seedu.address.logic.parser.patient;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.patient.DeletePatientCommand;
 import seedu.address.logic.parser.Parser;
-import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeleteCommand object
+ * Parses input arguments and creates a new DeletePatientCommand object
  */
 public class DeletePatientCommandParser implements Parser<DeletePatientCommand> {
 
@@ -19,13 +17,12 @@ public class DeletePatientCommandParser implements Parser<DeletePatientCommand> 
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeletePatientCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeletePatientCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePatientCommand.MESSAGE_USAGE), pe);
+        String lowercasePatientName = args.trim().toLowerCase();
+        if (lowercasePatientName.length() == 0) {
+            //case when the user calls deletePatient command without arguments for patient name
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePatientCommand.MESSAGE_USAGE));
+        } else {
+            return new DeletePatientCommand(args);
         }
     }
-
 }

--- a/src/main/java/seedu/address/model/patient/Patient.java
+++ b/src/main/java/seedu/address/model/patient/Patient.java
@@ -10,12 +10,11 @@ import java.util.Objects;
  */
 public class Patient {
 
-    // Identity fields
-    private final Name name;
+    private final Name name; //identifier field
     private final Temperature temperature;
     private final PeriodOfStay periodOfStay;
-    private final Phone phone;
-    private final Age age;
+    private final Phone phone; //identifier field
+    private final Age age; //identifier field
     private final Comment comment; // an optional field, if null is initialised to "-"
 
     /**
@@ -57,7 +56,7 @@ public class Patient {
     }
 
     /**
-     * Returns true if both patients of the same name have at least one other identity field that is the same.
+     * Returns true if both patients of the same name have same age and phone number.
      * This defines a weaker notion of equality between two patients.
      */
     public boolean isSamePatient(Patient otherPatient) {
@@ -68,7 +67,6 @@ public class Patient {
         return otherPatient != null
                 && otherPatient.getName().equals(getName())
                 && otherPatient.getPhone().equals(getPhone())
-                && otherPatient.getPeriodOfStay().equals(getPeriodOfStay())
                 && otherPatient.getAge().equals(getAge());
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PATIENT_NAME_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.NewCommandTestUtil.AGE_DESC_AMY;
 import static seedu.address.logic.commands.NewCommandTestUtil.NAME_DESC_AMY;
@@ -64,8 +64,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
+        String deleteCommand = "deletepatient IDoNotExist";
+        assertCommandException(deleteCommand, MESSAGE_INVALID_PATIENT_NAME_INPUT);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/patient/DeletePatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/patient/DeletePatientCommandTest.java
@@ -4,15 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.NewCommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.NewCommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.NewCommandTestUtil.showPatientAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PATIENT;
 import static seedu.address.testutil.TypicalPatients.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -28,9 +25,10 @@ public class DeletePatientCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new RoomList());
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
+    public void execute_validNameUnfilteredList_success() {
         Patient patientToDelete = model.getFilteredPatientList().get(INDEX_FIRST_PATIENT.getZeroBased());
-        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(INDEX_FIRST_PATIENT);
+        String patientToDeleteName = patientToDelete.getName().toString();
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(patientToDeleteName);
 
         String expectedMessage = String.format(DeletePatientCommand.MESSAGE_DELETE_PATIENT_SUCCESS, patientToDelete);
 
@@ -41,52 +39,22 @@ public class DeletePatientCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPatientList().size() + 1);
-        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(outOfBoundIndex);
-
-        assertCommandFailure(deletePatientCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_validIndexFilteredList_success() {
-        showPatientAtIndex(model, INDEX_FIRST_PATIENT);
-
-        Patient patientToDelete = model.getFilteredPatientList().get(INDEX_FIRST_PATIENT.getZeroBased());
-        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(INDEX_FIRST_PATIENT);
-
-        String expectedMessage = String.format(DeletePatientCommand.MESSAGE_DELETE_PATIENT_SUCCESS, patientToDelete);
-
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new RoomList());
-        expectedModel.deletePatient(patientToDelete);
-        showNoPatient(expectedModel);
-
-        assertCommandSuccess(deletePatientCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showPatientAtIndex(model, INDEX_FIRST_PATIENT);
-
-        Index outOfBoundIndex = INDEX_SECOND_PATIENT;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPatientList().size());
-
-        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(outOfBoundIndex);
-
-        assertCommandFailure(deletePatientCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
+    public void execute_invalidNameUnfilteredList_throwsCommandException() {
+        String invalidPatientName = "Obviously invalid name";
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(invalidPatientName);
+        assertCommandFailure(deletePatientCommand, model, Messages.MESSAGE_INVALID_PATIENT_NAME_INPUT);
     }
 
     @Test
     public void equals() {
-        DeletePatientCommand deleteFirstCommand = new DeletePatientCommand(INDEX_FIRST_PATIENT);
-        DeletePatientCommand deleteSecondCommand = new DeletePatientCommand(INDEX_SECOND_PATIENT);
+        DeletePatientCommand deleteFirstCommand = new DeletePatientCommand("Jane Doe");
+        DeletePatientCommand deleteSecondCommand = new DeletePatientCommand("John Doe");
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
-        // same values -> returns true
-        DeletePatientCommand deleteFirstCommandCopy = new DeletePatientCommand(INDEX_FIRST_PATIENT);
+        // same names of patient -> returns true
+        DeletePatientCommand deleteFirstCommandCopy = new DeletePatientCommand("jane doe");
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/patient/EditPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/patient/EditPatientCommandTest.java
@@ -127,7 +127,7 @@ public class EditPatientCommandTest {
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditPatientCommand editCommand = new EditPatientCommand("Unknown", descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PATIENT_NAME_INPUT);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,11 +17,14 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.patient.AddPatientCommand;
 import seedu.address.logic.commands.patient.DeletePatientCommand;
+import seedu.address.logic.commands.patient.EditPatientCommand;
+import seedu.address.logic.commands.patient.EditPatientCommand.EditPatientDescriptor;
 import seedu.address.logic.commands.patient.FindPatientCommand;
 import seedu.address.logic.commands.patient.ListPatientCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.patient.NameContainsKeywordsPredicate;
 import seedu.address.model.patient.Patient;
+import seedu.address.testutil.EditPatientDescriptorBuilder;
 import seedu.address.testutil.PatientBuilder;
 import seedu.address.testutil.PatientUtil;
 
@@ -31,7 +33,7 @@ public class AddressBookParserTest {
     private final AddressBookParser parser = new AddressBookParser();
 
     @Test
-    public void parseCommand_add() throws Exception {
+    public void parseCommand_addPatient() throws Exception {
         Patient patient = new PatientBuilder().build();
         AddPatientCommand command = (AddPatientCommand) parser.parseCommand(PatientUtil.getAddPatientCommand(patient));
         assertEquals(new AddPatientCommand(patient), command);
@@ -44,22 +46,20 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_delete() throws Exception {
+    public void parseCommand_deletePatient() throws Exception {
         DeletePatientCommand command = (DeletePatientCommand) parser.parseCommand(
-                DeletePatientCommand.COMMAND_WORD + " " + INDEX_FIRST_PATIENT.getOneBased());
-        assertEquals(new DeletePatientCommand(INDEX_FIRST_PATIENT), command);
+                DeletePatientCommand.COMMAND_WORD + " " + "Alice Pauline");
+        assertEquals(new DeletePatientCommand("Alice Pauline"), command);
     }
 
-    /*
     @Test
-    public void parseCommand_edit() throws Exception {
+    public void parseCommand_editPatient() throws Exception {
         Patient patient = new PatientBuilder().build();
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(patient).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PATIENT.getOneBased() + " " + PatientUtil.getEditPatientDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PATIENT, descriptor), command);
+        EditPatientCommand command = (EditPatientCommand) parser.parseCommand(EditPatientCommand.COMMAND_WORD + " "
+                + patient.getName() + " " + PatientUtil.getEditPatientDescriptorDetails(descriptor));
+        assertEquals(new EditPatientCommand(patient.getName().toString(), descriptor), command);
     }
-     */
 
     @Test
     public void parseCommand_exit() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/patient/AddPatientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/patient/AddPatientCommandParserTest.java
@@ -25,6 +25,7 @@ import static seedu.address.logic.commands.NewCommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.NewCommandTestUtil.VALID_TEMP_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalPatients.AMY;
 import static seedu.address.testutil.TypicalPatients.BOB;
 
 import org.junit.jupiter.api.Test;
@@ -72,16 +73,13 @@ public class AddPatientCommandParserTest {
                 + PHONE_DESC_BOB + AGE_DESC_AMY + AGE_DESC_BOB, new AddPatientCommand(expectedPatient));
     }
 
-    /* for remark TODO
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        Patient expectedPatient = new PatientBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY ,
-                new AddPatientCommand(expectedPatient));
+        // no comments
+        Patient expectedPatient = new PatientBuilder(AMY).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + TEMP_DESC_AMY + PERIOD_DESC_AMY
+                + PHONE_DESC_AMY + AGE_DESC_AMY, new AddPatientCommand(expectedPatient));
     }
-
-    */
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {

--- a/src/test/java/seedu/address/logic/parser/patient/DeletePatientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/patient/DeletePatientCommandParserTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser.patient;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,12 +21,12 @@ public class DeletePatientCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeletePatientCommand(INDEX_FIRST_PATIENT));
+        assertParseSuccess(parser, "Mary Doe", new DeletePatientCommand("Mary Doe"));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeletePatientCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/patient/PatientTest.java
+++ b/src/test/java/seedu/address/model/patient/PatientTest.java
@@ -34,9 +34,9 @@ public class PatientTest {
         editedAlice = new PatientBuilder(ALICE).withName(VALID_NAME_BOB).build();
         Assertions.assertFalse(ALICE.isSamePatient(editedAlice));
 
-        //different period of stay -> returns false
+        //different period of stay but same name, phone and age -> returns true
         editedAlice = new PatientBuilder(ALICE).withPeriodOfStay(VALID_PERIOD_BOB).build();
-        Assertions.assertFalse(ALICE.isSamePatient(editedAlice));
+        Assertions.assertTrue(ALICE.isSamePatient(editedAlice));
 
         // same name, same phone, different attributes -> returns false
         editedAlice = new PatientBuilder(ALICE).withTemperature(VALID_TEMP_BOB)
@@ -50,6 +50,10 @@ public class PatientTest {
         //diff comments but all attributes same -> returns true
         editedAlice = new PatientBuilder(ALICE).withComment(COMMENT).build();
         Assertions.assertTrue(ALICE.isSamePatient(editedAlice));
+
+        //different age but the rest same -> returns false
+        editedAlice = new PatientBuilder(ALICE).withAge(VALID_AGE_BOB).build();
+        Assertions.assertFalse(ALICE.isSamePatient(editedAlice));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PatientUtil.java
+++ b/src/test/java/seedu/address/testutil/PatientUtil.java
@@ -1,12 +1,14 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.parser.patient.PatientCliSyntax.PREFIX_AGE;
+import static seedu.address.logic.parser.patient.PatientCliSyntax.PREFIX_COMMENTS;
 import static seedu.address.logic.parser.patient.PatientCliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.patient.PatientCliSyntax.PREFIX_PERIOD_OF_STAY;
 import static seedu.address.logic.parser.patient.PatientCliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.patient.PatientCliSyntax.PREFIX_TEMP;
 
 import seedu.address.logic.commands.patient.AddPatientCommand;
+import seedu.address.logic.commands.patient.EditPatientCommand.EditPatientDescriptor;
 import seedu.address.model.patient.Patient;
 
 /**
@@ -34,21 +36,17 @@ public class PatientUtil {
         return sb.toString();
     }
 
-    /*
-    public static String getEditPatientDescriptorDetails(EditPatient descriptor) {
+
+    public static String getEditPatientDescriptorDetails(EditPatientDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
-        descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
-        if (descriptor.getTags().isPresent()) {
-            Set<Tag> tags = descriptor.getTags().get();
-            if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
-            } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
-            }
-        }
+        descriptor.getTemperature().ifPresent(temperature -> sb.append(PREFIX_TEMP).append(temperature.value)
+                                    .append(" "));
+        descriptor.getPeriodOfStay().ifPresent(periodOfStay -> sb.append(PREFIX_PERIOD_OF_STAY)
+                                    .append(periodOfStay.toString()).append(" "));
+        descriptor.getAge().ifPresent(age -> sb.append(PREFIX_AGE).append(age.value).append(" "));
+        descriptor.getComment().ifPresent(comment -> sb.append(PREFIX_COMMENTS).append(comment.value).append(" "));
         return sb.toString();
     }
-     */
 }

--- a/src/test/java/seedu/address/testutil/TypicalPatients.java
+++ b/src/test/java/seedu/address/testutil/TypicalPatients.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.NewCommandTestUtil.COMMENT_AMY;
 import static seedu.address.logic.commands.NewCommandTestUtil.VALID_AGE_AMY;
 import static seedu.address.logic.commands.NewCommandTestUtil.VALID_AGE_BOB;
 import static seedu.address.logic.commands.NewCommandTestUtil.VALID_NAME_AMY;
@@ -56,7 +57,7 @@ public class TypicalPatients {
     // Manually added - Patient's details found in {@code CommandTestUtil}
     public static final Patient AMY = new PatientBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withTemperature(VALID_TEMP_AMY).withPeriodOfStay(VALID_PERIOD_AMY)
-            .withAge(VALID_AGE_AMY).build();
+            .withAge(VALID_AGE_AMY).withComment(COMMENT_AMY).build();
     public static final Patient BOB = new PatientBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withTemperature(VALID_TEMP_BOB).withPeriodOfStay(VALID_PERIOD_BOB)
             .withAge(VALID_AGE_BOB).build();


### PR DESCRIPTION
1. Complete deletepatient command and its test cases: deletepatient works by "deletepatient [NAME]". (Initially, I was thinking if we should use more identifiers to identify the person other than the name but I realised that will be quite out of place since editPatient and allocate commands work by using the name only as an identifier. Using name only will keep it consistent.)

2. Ensure consistency in patient-related messages.

3. Add deletepatient command in UG.

