### PR TITLE
Fix task index not updating in search results

### DIFF
--- a/src/main/java/seedu/address/ui/RoomTaskDetailsPanel.java
+++ b/src/main/java/seedu/address/ui/RoomTaskDetailsPanel.java
@@ -1,12 +1,17 @@
 package seedu.address.ui;
 
+import java.util.logging.Logger;
+
 import javafx.beans.binding.Bindings;
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.room.Room;
 import seedu.address.model.task.Task;
 
@@ -21,6 +26,8 @@ public class RoomTaskDetailsPanel extends UiPart<Region> {
     private static final String FXML = "RoomTaskDetailsPanel.fxml";
 
     public final Room room;
+
+    private final Logger logger = LogsCenter.getLogger(RoomTaskDetailsPanel.class);
 
     @FXML
     private VBox taskDetailsBox;
@@ -37,6 +44,7 @@ public class RoomTaskDetailsPanel extends UiPart<Region> {
         this.room = room;
         setTaskDetails(room.getFilteredTasks());
         setCellSize(room.getFilteredTasks());
+        updateDetailsIfChanged(room.getReadOnlyTasks());
     }
 
     /**
@@ -65,6 +73,30 @@ public class RoomTaskDetailsPanel extends UiPart<Region> {
     private void setCellSize(ObservableList<Task> taskList) {
         taskListView.setFixedCellSize(LIST_CELL_HEIGHT);
         taskListView.prefHeightProperty().bind(Bindings.size(taskList).multiply(LIST_CELL_HEIGHT));
+    }
+
+    /**
+     * Attaches a listener to {@code roomTaskList}. {@code roomTaskList} should be the original task list of
+     * the room, i.e. not the filtered list.
+     *
+     * Fixes the issue of task index not refreshing when a new task is added and is not
+     * in the filtered list.
+     *
+     * @param roomTaskList The task list to listen to for changes.
+     */
+    private void updateDetailsIfChanged(ObservableList<Task> roomTaskList) {
+        roomTaskList.addListener(new ListChangeListener<Task>() {
+            @Override
+            public void onChanged(Change<? extends Task> change) {
+                while (change.next()) {
+                    int indexOfChange = change.getFrom();
+                    Index index = Index.fromZeroBased(indexOfChange);
+                    logger.info("Changes detected in Task " + index.getOneBased()
+                            + ". Updating RoomTaskDetailsPanel...");
+                    taskListView.setCellFactory(listView -> new TaskListViewCell());
+                }
+            }
+        });
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/RoomTaskListPanel.java
+++ b/src/main/java/seedu/address/ui/RoomTaskListPanel.java
@@ -18,6 +18,7 @@ import seedu.address.model.room.Room;
 public class RoomTaskListPanel extends UiPart<Region> {
 
     private static final String FXML = "RoomTaskListPanel.fxml";
+
     private final Logger logger = LogsCenter.getLogger(RoomTaskListPanel.class);
 
     @FXML
@@ -61,16 +62,16 @@ public class RoomTaskListPanel extends UiPart<Region> {
 
     //@@author w-yeehong
     /**
-     * Attaches a listener to {@code roomTaskList}, repopulating the panel whenever
+     * Attaches a listener to {@code roomList}, repopulating the panel whenever
      * there are removals in the list of rooms.
      *
      * Fixes the issue of the panel not refreshing when a room is removed from the
      * list of rooms.
      *
-     * @param roomTaskList to listen for changes.
+     * @param roomList The room list to listen to for changes.
      */
-    private void updateDetailsIfChanged(ObservableList<Room> roomTaskList) {
-        roomTaskList.addListener(new ListChangeListener<Room>() {
+    private void updateDetailsIfChanged(ObservableList<Room> roomList) {
+        roomList.addListener(new ListChangeListener<Room>() {
             @Override
             public void onChanged(Change<? extends Room> change) {
                 while (change.next()) {
@@ -78,7 +79,7 @@ public class RoomTaskListPanel extends UiPart<Region> {
                     Index index = Index.fromZeroBased(indexOfChange);
                     logger.info("Changes detected in Room " + index.getOneBased()
                             + ". Updating RoomTaskListPanel...");
-                    resetPanel(roomTaskList);
+                    resetPanel(roomList);
                 }
             }
         });


### PR DESCRIPTION
Let's add a listener on the original `ObservableList` of the tasks in a room to monitor for changes. This allows the task indexes to be updated upon adding or deleting a task not found within the search results.