### PR TITLE
Update error message for parsing room and task numbers

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,46 +1,56 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.room.RoomCliSyntax;
+import seedu.address.logic.parser.task.TaskCliSyntax;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MESSAGE_INVALID_NUMBER = "Please only enter positive integers. E.g. 6 ";
+    public static final String MESSAGE_INVALID_UNSIGNED_INT = "Please ensure that the value "
+            + "for the field \"%1$s\" is a number between 1 and " + Integer.MAX_VALUE + "."
+            + "\nYour current input: %2$s";
+
+    //@author LeeMingDe
+    /**
+     * Parses {@code roomNumber} into an {@code Integer} and returns it.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the specified room number is invalid (not non-zero unsigned integer).
+     */
+    public static Integer parseRoomNumber(String roomNumber) throws ParseException {
+        String trimmedRoomNumber = roomNumber.trim();
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedRoomNumber)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_UNSIGNED_INT,
+                    RoomCliSyntax.PREFIX_ROOM_NUMBER, roomNumber));
+        }
+        return Integer.parseInt(trimmedRoomNumber);
+    }
+    //@author LeeMingDe
 
     /**
-     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
-     * trimmed.
-     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     * Parses {@code taskIndex} into an {@code Index} and returns it.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the specified task index is invalid (not non-zero unsigned integer).
      */
-    public static Index parseIndex(String oneBasedIndex) throws ParseException {
-        String trimmedIndex = oneBasedIndex.trim();
+    public static Index parseTaskIndex(String taskIndex) throws ParseException {
+        requireNonNull(taskIndex);
+        String trimmedIndex = taskIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(String.format(MESSAGE_INVALID_UNSIGNED_INT,
+                    TaskCliSyntax.PREFIX_TASK_NUMBER, taskIndex));
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
-
-    //@author LeeMingDe
-    /**
-     * Parses {@code integer} into an {@code Integer} and returns it. Leading and trailing whitespaces will be
-     * trimmed.
-     * @throws ParseException if the specified integer is invalid (not non-zero unsigned integer).
-     */
-    public static Integer parsePositiveInteger(String integer) throws ParseException {
-        String trimmedInteger = integer.trim();
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedInteger)) {
-            throw new ParseException(MESSAGE_INVALID_NUMBER);
-        }
-        return Integer.parseInt(trimmedInteger);
-    }
-    //@author LeeMingDe
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -27,6 +27,7 @@ public class ParserUtil {
      * @throws ParseException if the specified room number is invalid (not non-zero unsigned integer).
      */
     public static Integer parseRoomNumber(String roomNumber) throws ParseException {
+        requireNonNull(roomNumber);
         String trimmedRoomNumber = roomNumber.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedRoomNumber)) {
             throw new ParseException(String.format(MESSAGE_INVALID_UNSIGNED_INT,

--- a/src/main/java/seedu/address/logic/parser/room/AllocateRoomCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/room/AllocateRoomCommandParser.java
@@ -34,7 +34,7 @@ public class AllocateRoomCommandParser implements Parser<AllocateRoomCommand> {
         Integer roomToBeAllocated;
         boolean toRemove = false;
         try {
-            roomToBeAllocated = ParserUtil.parsePositiveInteger(argMultimap.getPreamble().trim());
+            roomToBeAllocated = ParserUtil.parseRoomNumber(argMultimap.getPreamble().trim());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AllocateRoomCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/room/SearchRoomCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/room/SearchRoomCommandParser.java
@@ -44,7 +44,7 @@ public class SearchRoomCommandParser implements Parser<SearchRoomCommand> {
             return new SearchRoomCommand(descriptor);
         }
         //definitely have prefix room number if no prefix name
-        Integer roomNumber = ParserUtil.parsePositiveInteger(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
+        Integer roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
         descriptor.setRoomNumber(roomNumber);
         return new SearchRoomCommand(descriptor);
 

--- a/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
@@ -36,7 +36,7 @@ public class AddTaskCommandParser implements Parser<AddTaskCommand> {
         }
 
         Description description = TaskParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
-        int roomNumber = ParserUtil.parsePositiveInteger(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
+        int roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
         DateTimeDue dueAt = TaskParserUtil.parseDateTimeDue(argMultimap.getValue(PREFIX_DUE_DATE)); // optional
 
         Task task = new Task(description, dueAt);

--- a/src/main/java/seedu/address/logic/parser/task/DeleteTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/DeleteTaskCommandParser.java
@@ -32,8 +32,8 @@ public class DeleteTaskCommandParser implements Parser<DeleteTaskCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE));
         }
 
-        int roomNumber = ParserUtil.parsePositiveInteger(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
-        Index taskNumber = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_TASK_NUMBER).get());
+        int roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
+        Index taskNumber = ParserUtil.parseTaskIndex(argMultimap.getValue(PREFIX_TASK_NUMBER).get());
 
         return new DeleteTaskCommand(roomNumber, taskNumber);
     }

--- a/src/main/java/seedu/address/logic/parser/task/EditTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/EditTaskCommandParser.java
@@ -43,8 +43,8 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
         }
 
         // Compulsory fields
-        int roomNumber = ParserUtil.parsePositiveInteger(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
-        Index taskIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_TASK_NUMBER).get());
+        int roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
+        Index taskIndex = ParserUtil.parseTaskIndex(argMultimap.getValue(PREFIX_TASK_NUMBER).get());
 
         // Optional fields
         EditTaskDescriptor editTaskDescriptor = new EditTaskDescriptor();

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -5,10 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_NUMBER;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
+import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_TASK_INDEX_ONE;
 
 import java.util.Optional;
 
@@ -19,48 +17,53 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class ParserUtilTest {
 
     @Test
-    public void parseIndex_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
+    public void parseRoomNumber_invalidInput_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseRoomNumber("10 a"));
     }
 
     @Test
-    public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () ->
-                ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+    public void parseRoomNumber_negativeInteger_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseRoomNumber("-1"));
     }
 
     @Test
-    public void parseIndex_validInput_success() throws Exception {
+    public void parseRoomNumber_outOfRangeInput_throwsParseException() {
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseRoomNumber(Long.toString(Integer.MAX_VALUE + 1)));
+    }
+
+    @Test
+    public void parseRoomNumber_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PATIENT, ParserUtil.parseIndex("1"));
+        assertEquals(1, ParserUtil.parseRoomNumber("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PATIENT, ParserUtil.parseIndex("  1  "));
+        assertEquals(1, ParserUtil.parseRoomNumber("  1  "));
     }
 
     @Test
-    public void parsePositiveInteger_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parsePositiveInteger("10 a"));
+    public void parseTaskIndex_invalidInput_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTaskIndex("10 a"));
     }
 
     @Test
-    public void parsePositiveInteger_negativeInteger_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_NUMBER, () ->
-                ParserUtil.parsePositiveInteger("-1"));
+    public void parseTaskIndex_negativeInteger_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTaskIndex("-1"));
     }
 
     @Test
-    public void parsePositiveInteger_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_NUMBER, () ->
-                ParserUtil.parsePositiveInteger(Long.toString(Integer.MAX_VALUE + 1)));
+    public void parseTaskIndex_outOfRangeInput_throwsParseException() {
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseTaskIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test
-    public void parsePositiveInteger_validInput_success() throws Exception {
+    public void parseTaskIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(1, ParserUtil.parsePositiveInteger("1"));
+        assertEquals(VALID_TASK_INDEX_ONE, ParserUtil.parseTaskIndex("1"));
+
         // Leading and trailing whitespaces
-        assertEquals(1, ParserUtil.parsePositiveInteger("  1  "));
+        assertEquals(VALID_TASK_INDEX_ONE, ParserUtil.parseTaskIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -17,6 +17,11 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class ParserUtilTest {
 
     @Test
+    public void parseRoomNumber_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseRoomNumber(null));
+    }
+
+    @Test
     public void parseRoomNumber_invalidInput_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseRoomNumber("10 a"));
     }
@@ -39,6 +44,11 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(1, ParserUtil.parseRoomNumber("  1  "));
+    }
+
+    @Test
+    public void parseTaskIndex_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseTaskIndex(null));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/room/SearchRoomCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/room/SearchRoomCommandParserTest.java
@@ -3,11 +3,11 @@ package seedu.address.logic.parser.room;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_NUMBER;
 import static seedu.address.testutil.command.PatientCommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.testutil.command.PatientCommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.testutil.command.PatientCommandTestUtil.TEMP_DESC_AMY;
 import static seedu.address.testutil.command.PatientCommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.testutil.command.RoomCommandTestUtil.INVALID_NON_NUMBER_ROOM_NUMBER;
 import static seedu.address.testutil.command.RoomCommandTestUtil.INVALID_NON_NUMBER_ROOM_NUMBER_DESC;
 import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_DESC_ONE;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_NAME_AMY_DESC;
@@ -16,6 +16,7 @@ import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMB
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.room.SearchRoomCommand;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.patient.Name;
 import seedu.address.testutil.SearchRoomDescriptorBuilder;
 
@@ -47,7 +48,9 @@ public class SearchRoomCommandParserTest {
         //invalid patient name prefix
         assertParseFailure(parser, INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS);
         //invalid room number prefix
-        assertParseFailure(parser, INVALID_NON_NUMBER_ROOM_NUMBER_DESC, MESSAGE_INVALID_NUMBER);
+        assertParseFailure(parser, INVALID_NON_NUMBER_ROOM_NUMBER_DESC,
+                String.format(ParserUtil.MESSAGE_INVALID_UNSIGNED_INT, RoomCliSyntax.PREFIX_ROOM_NUMBER,
+                INVALID_NON_NUMBER_ROOM_NUMBER));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/task/AddTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/AddTaskCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalTasks.REMIND_PATIENT;
 import static seedu.address.testutil.command.GeneralCommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.testutil.command.GeneralCommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.testutil.command.RoomCommandTestUtil.INVALID_ROOM_NUMBER;
 import static seedu.address.testutil.command.RoomCommandTestUtil.INVALID_ROOM_NUMBER_DESC;
 import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_DESC_ONE;
 import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_EIGHT_DESC;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.task.AddTaskCommand;
 import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.room.RoomCliSyntax;
 import seedu.address.model.task.DateTimeDue;
 import seedu.address.model.task.Task;
 import seedu.address.testutil.TaskBuilder;
@@ -88,11 +90,13 @@ public class AddTaskCommandParserTest {
 
         // invalid room number
         assertParseFailure(parser, DESCRIPTION_DESC_REMIND_PATIENT + INVALID_ROOM_NUMBER_DESC
-                + DESCRIPTION_DESC_REMIND_PATIENT, ParserUtil.MESSAGE_INVALID_NUMBER);
+                + DESCRIPTION_DESC_REMIND_PATIENT, String.format(ParserUtil.MESSAGE_INVALID_UNSIGNED_INT,
+                RoomCliSyntax.PREFIX_ROOM_NUMBER, INVALID_ROOM_NUMBER));
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, DESCRIPTION_DESC_REMIND_PATIENT + INVALID_ROOM_NUMBER_DESC
-                + INVALID_DATETIME_DUE_VALUE_DESC, ParserUtil.MESSAGE_INVALID_NUMBER);
+                + INVALID_DATETIME_DUE_VALUE_DESC, String.format(ParserUtil.MESSAGE_INVALID_UNSIGNED_INT,
+                RoomCliSyntax.PREFIX_ROOM_NUMBER, INVALID_ROOM_NUMBER));
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + DESCRIPTION_DESC_REMIND_PATIENT

--- a/src/test/java/seedu/address/logic/parser/task/DeleteTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/DeleteTaskCommandParserTest.java
@@ -5,10 +5,12 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.command.GeneralCommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.testutil.command.GeneralCommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.testutil.command.RoomCommandTestUtil.INVALID_ROOM_NUMBER;
 import static seedu.address.testutil.command.RoomCommandTestUtil.INVALID_ROOM_NUMBER_DESC;
 import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_EIGHT_DESC;
 import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_SEVEN_DESC;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMBER_SEVEN;
+import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_TASK_NUMBER;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_TASK_NUMBER_DESC;
 import static seedu.address.testutil.command.TaskCommandTestUtil.TASK_NUMBER_DESC_ONE;
 import static seedu.address.testutil.command.TaskCommandTestUtil.TASK_NUMBER_DESC_TWO;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.task.DeleteTaskCommand;
 import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.room.RoomCliSyntax;
 
 public class DeleteTaskCommandParserTest {
 
@@ -53,11 +56,13 @@ public class DeleteTaskCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid room number
         assertParseFailure(parser, INVALID_ROOM_NUMBER_DESC + TASK_NUMBER_DESC_ONE,
-                ParserUtil.MESSAGE_INVALID_NUMBER);
+                String.format(ParserUtil.MESSAGE_INVALID_UNSIGNED_INT, RoomCliSyntax.PREFIX_ROOM_NUMBER,
+                INVALID_ROOM_NUMBER));
 
         // invalid task number
         assertParseFailure(parser, ROOM_NUMBER_SEVEN_DESC + INVALID_TASK_NUMBER_DESC,
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                String.format(ParserUtil.MESSAGE_INVALID_UNSIGNED_INT, TaskCliSyntax.PREFIX_TASK_NUMBER,
+                INVALID_TASK_NUMBER));
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + ROOM_NUMBER_SEVEN_DESC + TASK_NUMBER_DESC_ONE,

--- a/src/test/java/seedu/address/logic/parser/task/EditTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/EditTaskCommandParserTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.command.GeneralCommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.testutil.command.GeneralCommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.testutil.command.RoomCommandTestUtil.INVALID_ROOM_NUMBER;
 import static seedu.address.testutil.command.RoomCommandTestUtil.INVALID_ROOM_NUMBER_DESC;
 import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_EIGHT_DESC;
 import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_SEVEN_DESC;
@@ -16,6 +17,7 @@ import static seedu.address.testutil.command.TaskCommandTestUtil.DESCRIPTION_DES
 import static seedu.address.testutil.command.TaskCommandTestUtil.DESCRIPTION_DESC_REMIND_PATIENT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DATETIME_DUE_FORMAT_DESC;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DATETIME_DUE_VALUE_DESC;
+import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_TASK_NUMBER;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_TASK_NUMBER_DESC;
 import static seedu.address.testutil.command.TaskCommandTestUtil.TASK_NUMBER_DESC_ONE;
 import static seedu.address.testutil.command.TaskCommandTestUtil.TASK_NUMBER_DESC_TWO;
@@ -29,6 +31,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.task.EditTaskCommand;
 import seedu.address.logic.commands.task.EditTaskCommand.EditTaskDescriptor;
 import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.room.RoomCliSyntax;
 import seedu.address.model.task.DateTimeDue;
 import seedu.address.model.task.Description;
 
@@ -114,15 +117,18 @@ public class EditTaskCommandParserTest {
 
         // invalid room number
         assertParseFailure(parser, INVALID_ROOM_NUMBER_DESC + TASK_NUMBER_DESC_ONE,
-                ParserUtil.MESSAGE_INVALID_NUMBER);
+                String.format(ParserUtil.MESSAGE_INVALID_UNSIGNED_INT, RoomCliSyntax.PREFIX_ROOM_NUMBER,
+                INVALID_ROOM_NUMBER));
 
         // invalid task number
         assertParseFailure(parser, ROOM_NUMBER_SEVEN_DESC + INVALID_TASK_NUMBER_DESC,
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                String.format(ParserUtil.MESSAGE_INVALID_UNSIGNED_INT, TaskCliSyntax.PREFIX_TASK_NUMBER,
+                INVALID_TASK_NUMBER));
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, ROOM_NUMBER_SEVEN_DESC + INVALID_TASK_NUMBER_DESC + DESCRIPTION_DESC_REMIND_PATIENT
-                + INVALID_DATETIME_DUE_VALUE_DESC, ParserUtil.MESSAGE_INVALID_INDEX);
+                + INVALID_DATETIME_DUE_VALUE_DESC, String.format(ParserUtil.MESSAGE_INVALID_UNSIGNED_INT,
+                TaskCliSyntax.PREFIX_TASK_NUMBER, INVALID_TASK_NUMBER));
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + ROOM_NUMBER_SEVEN_DESC + TASK_NUMBER_DESC_ONE


### PR DESCRIPTION
If a user mistakenly types a non-number or number that is lesser than 1 or greater than 2147483647 for the `r/` and `t/` syntaxes, the following error message is now shown:

![image](https://user-images.githubusercontent.com/69478469/97916056-69598200-1d8d-11eb-9f4a-09ced22ed5af.png)
