### PR TITLE
Display task index in Task UI

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -10,7 +10,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyList;
 import seedu.address.model.patient.Patient;
 import seedu.address.model.room.Room;
-import seedu.address.model.task.Task;
+import seedu.address.model.room.RoomTaskAssociation;
 
 /**
  * API of the Logic component
@@ -42,8 +42,8 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of rooms. */
     ObservableList<Room> getFilteredRoomList();
 
-    /** Returns an unmodifiable view of the filtered list of tasks. */
-    ObservableList<Task> getFilteredTaskList();
+    /** Returns an unmodifiable view of the filtered list of room-task associations. */
+    ObservableList<RoomTaskAssociation> getFilteredRoomTaskRecords();
 
     /**
      * Returns the user prefs' Covigent file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -16,7 +16,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyList;
 import seedu.address.model.patient.Patient;
 import seedu.address.model.room.Room;
-import seedu.address.model.task.Task;
+import seedu.address.model.room.RoomTaskAssociation;
 import seedu.address.storage.Storage;
 
 
@@ -98,7 +98,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Task> getFilteredTaskList() {
-        return model.getFilteredTaskList();
+    public ObservableList<RoomTaskAssociation> getFilteredRoomTaskRecords() {
+        return model.getFilteredRoomTaskRecords();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
@@ -106,7 +106,7 @@ public class EditTaskCommand extends Command {
         Description updatedDescription = editTaskDescriptor.getDescription().orElse(taskToEdit.getDescription());
         DateTimeDue updatedDueAt = editTaskDescriptor.getDateTimeDue().orElse(taskToEdit.getDueAt());
 
-        return new Task(updatedDescription, updatedDueAt, taskToEdit.getTaskRoomNumber());
+        return new Task(updatedDescription, updatedDueAt);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/task/ListTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/ListTaskCommand.java
@@ -19,7 +19,7 @@ public class ListTaskCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
+        model.updateTasksInFilteredRoomTaskRecords(PREDICATE_SHOW_ALL_TASKS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/task/SearchTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/SearchTaskCommand.java
@@ -64,11 +64,11 @@ public class SearchTaskCommand extends Command {
         }
 
         if (taskListWithDesirableResult.size() < 1) {
-            model.updateFilteredTaskList(datePredicate);
+            model.updateTasksInFilteredRoomTaskRecords(datePredicate);
             throw new CommandException(MESSAGE_TASK_NOT_FOUND);
         }
         assert taskListWithDesirableResult.size() >= 1;
-        model.updateFilteredTaskList(datePredicate);
+        model.updateTasksInFilteredRoomTaskRecords(datePredicate);
         return new CommandResult(String.format(MESSAGE_SEARCH_TASK_SUCCESS));
     }
 

--- a/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
@@ -39,7 +39,7 @@ public class AddTaskCommandParser implements Parser<AddTaskCommand> {
         int roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
         DateTimeDue dueAt = TaskParserUtil.parseDateTimeDue(argMultimap.getValue(PREFIX_DUE_DATE)); // optional
 
-        Task task = new Task(description, dueAt, roomNumber);
+        Task task = new Task(description, dueAt);
 
         return new AddTaskCommand(task, roomNumber);
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -253,11 +253,11 @@ public interface Model {
     void setTaskToRoom(Task target, Task editedTask, Room room);
 
     /**
-     * Update the filterTaskList with {@code datePredicate}.
+     * Update the tasks in {@code filteredRoomTaskRecords} with {@code taskPredicate}.
      *
-     * @param datePredicate The dueDate predicate.
+     * @param taskPredicate The predicate to filter the tasks.
      */
-    void updateFilteredTaskList(Predicate<Task> datePredicate);
+    void updateTasksInFilteredRoomTaskRecords(Predicate<Task> taskPredicate);
 
     /**
      * Returns an unmodifiable view of the list of {@code RoomTaskAssociation} backed by the

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.model.patient.Name;
 import seedu.address.model.patient.Patient;
 import seedu.address.model.room.Room;
+import seedu.address.model.room.RoomTaskAssociation;
 import seedu.address.model.task.Task;
 
 /**
@@ -63,6 +64,16 @@ public interface Model {
     ReadOnlyList<Patient> getPatientRecords();
 
     /**
+     * Replaces room list with the data in {@code covigentApp}.
+     */
+    void setRoomList(ReadOnlyList<Room> rooms);
+
+    /**
+     * Returns the room task records.
+     */
+    ReadOnlyList<RoomTaskAssociation> getRoomTaskRecords();
+
+    /**
      * Returns true if a patient with the same identity as {@code patient} exists in the patient records.
      */
     boolean hasPatient(Patient patient);
@@ -113,11 +124,6 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPatientList(Predicate<Patient> predicate);
-
-    /**
-     * Replaces room list with the data in {@code covigentApp}.
-     */
-    void setRoomList(ReadOnlyList<Room> rooms);
 
     /**
      * Returns total number of rooms in the application's {@code RoomList}.
@@ -254,8 +260,8 @@ public interface Model {
     void updateFilteredTaskList(Predicate<Task> datePredicate);
 
     /**
-     * Returns an unmodifiable view of the list of {@code Task} backed by the internal list of
-     * {@code RoomTaskRecords}.
+     * Returns an unmodifiable view of the list of {@code RoomTaskAssociation} backed by the
+     * internal list of {@code RoomTaskRecords}.
      */
-    ObservableList<Task> getFilteredTaskList();
+    ObservableList<RoomTaskAssociation> getFilteredRoomTaskRecords();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -66,7 +66,7 @@ public class ModelManager implements Model {
         ObservableList<Task> taskList = FXCollections.observableArrayList();
         ObservableList<Room> roomsList = roomList.getRoomObservableList();
         for (Room room : roomsList) {
-            taskList = FXCollections.concat(taskList, room.getFilteredTasks());
+            taskList = FXCollections.concat(taskList, room.getReadOnlyTasks());
         }
         return taskList;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -343,9 +343,9 @@ public class ModelManager implements Model {
     //=========== Filtered RoomTaskRecords Accessors ========================================================
 
     @Override
-    public void updateFilteredTaskList(Predicate<Task> datePredicate) {
-        requireNonNull(datePredicate);
-        //filteredTasks.setPredicate(datePredicate);
+    public void updateTasksInFilteredRoomTaskRecords(Predicate<Task> taskPredicate) {
+        requireNonNull(taskPredicate);
+        filteredRoomTaskRecords.setPredicate(roomTaskAssociation -> taskPredicate.test(roomTaskAssociation.getTask()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/RoomTaskRecords.java
+++ b/src/main/java/seedu/address/model/RoomTaskRecords.java
@@ -54,9 +54,6 @@ public class RoomTaskRecords implements ReadOnlyList<Task> {
                         int roomNumber = changedRoom.getRoomNumber();
                         ArrayList<Task> updatedTaskList = new ArrayList<>();
                         for (Task task : internalList) {
-                            if (task.getTaskRoomNumber() != roomNumber) {
-                                updatedTaskList.add(task);
-                            }
                         }
                         updatedTaskList.addAll(changedRoom.getReadOnlyTasks());
                         internalList.setAll(updatedTaskList);

--- a/src/main/java/seedu/address/model/RoomTaskRecords.java
+++ b/src/main/java/seedu/address/model/RoomTaskRecords.java
@@ -8,6 +8,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.room.Room;
 import seedu.address.model.room.RoomTaskAssociation;
 import seedu.address.model.task.Task;
@@ -105,13 +106,8 @@ public class RoomTaskRecords implements ReadOnlyList<RoomTaskAssociation> {
             @Override
             public void onChanged(Change<? extends Room> change) {
                 while (change.next()) {
-                    // Minor optimization; new rooms have no tasks and hence do not need associations to be refreshed
-                    if (!change.wasAdded()) {
-                        // Recreate all room-task assocations; caters to initroom
-                        createRoomTaskAssociations(roomList);
-                        logger.fine("Changes detected in Room #" + change.getFrom()
-                                + ". Updating room-task associations...");
-                    }
+                    logger.fine("Changes detected in list of rooms. Updating room-task associations...");
+                    createRoomTaskAssociations(roomList);
                 }
             }
         });

--- a/src/main/java/seedu/address/model/RoomTaskRecords.java
+++ b/src/main/java/seedu/address/model/RoomTaskRecords.java
@@ -8,7 +8,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.room.Room;
 import seedu.address.model.room.RoomTaskAssociation;
 import seedu.address.model.task.Task;

--- a/src/main/java/seedu/address/model/RoomTaskRecords.java
+++ b/src/main/java/seedu/address/model/RoomTaskRecords.java
@@ -1,69 +1,124 @@
 package seedu.address.model;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.room.Room;
+import seedu.address.model.room.RoomTaskAssociation;
 import seedu.address.model.task.Task;
 
-//@@author chiamyunqing
 /**
- * The RoomTaskRecords class collects and updates all the Tasks from the rooms.
- * It exists mainly for the purpose of Task tab UI and is an Observer for changes in
- * RoomList.
+ * RoomTaskRecords exists mainly for the purpose of exposing an ObservableList for the user interface of
+ * {@code Task} to display the list of tasks in all {@code Room}.
+ *
+ * It stores a list of {@code RoomTaskAssociation}. {@code RoomTaskAssociation} is preferred to {@code Task}
+ * as it provides an API to quickly query room number and task index of a task.
+ *
+ * RoomTaskRecords follows the Singleton pattern. Solution adapted with modifications from:
+ * https://stackoverflow.com/questions/1050991/singleton-with-arguments-in-java
  */
-public class RoomTaskRecords implements ReadOnlyList<Task> {
+public class RoomTaskRecords implements ReadOnlyList<RoomTaskAssociation> {
 
-    private final ObservableList<Task> internalList;
-    private final ObservableList<Task> internalUnmodifiableList;
+    private static RoomTaskRecords theOne = null;
 
-    /**
-     * Constructs a listener to roomList so that task list is updated whenever
-     * there's a change in roomList
-     * @param taskList stores all the tasks in the rooms.
-     * @param roomList stores all the rooms.
-     */
-    public RoomTaskRecords(ObservableList<Task> taskList, ObservableList<Room> roomList) {
-        updateTaskListIfChanged(roomList);
-        internalList = taskList;
-        internalUnmodifiableList = FXCollections.unmodifiableObservableList(internalList);
+    private static final Logger logger = LogsCenter.getLogger(RoomTaskRecords.class);
+
+    private final ObservableList<RoomTaskAssociation> internalList = FXCollections.observableArrayList();
+    private final ObservableList<RoomTaskAssociation> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    private RoomTaskRecords() { // set to private to ensure that creation is done through init(...) method
     }
 
     /**
-     * Whenever there's a change in room list, we will force update of tasklist
-     * to reload the tasks in that room.
+     * Returns the RoomTaskRecords.
+     *
+     * @throws AssertionError if RoomTaskRecords has not been initialized.
      */
-    public void updateTaskListIfChanged(ObservableList<Room> roomList) {
+    public static RoomTaskRecords getInstance() {
+        if (theOne == null) {
+            throw new AssertionError("RoomTaskRecords has to be initialized first.");
+        }
+
+        return theOne;
+    }
+
+    /**
+     * Creates and initializes the RoomTaskRecords. The information about the rooms and the tasks in
+     * those rooms are obtained from {@code roomList}. A listener is attached to {@code roomList} to
+     * ensure that the associations between rooms and tasks are synchronized even when there are
+     * changes to {@code roomList}.
+     *
+     * Only one instance of RoomTaskRecords can be created.
+     *
+     * @param roomList The list of rooms from which to create the associations between room and task.
+     * @return The singleton instance of RoomTaskRecords.
+     * @throw AssertionError if RoomTaskRecords has already been initialized
+     */
+    public static synchronized RoomTaskRecords init(ObservableList<Room> roomList) {
+        if (theOne != null) {
+            throw new AssertionError("RoomTaskRecords has already been initialized.");
+        }
+
+        logger.finer("Creating RoomTaskRecords and attaching a listener to refresh room-task associations...");
+
+        theOne = new RoomTaskRecords();
+        theOne.createRoomTaskAssociations(roomList);
+        theOne.updateAssociationIfChanged(roomList);
+
+        logger.finer("Successfully attached listener to RoomTaskRecords.");
+
+        return theOne;
+    }
+
+    /**
+     * Creates the associations between each room and all the tasks in the rooms.
+     * These associations are stored into {@code internalList}.
+     */
+    private void createRoomTaskAssociations(ObservableList<Room> roomList) {
+        List<RoomTaskAssociation> associations = new ArrayList<>();
+
+        for (Room room : roomList) {
+            int taskIndex = 1;
+            for (Task task : room.getReadOnlyTasks()) {
+                associations.add(new RoomTaskAssociation(room, task, taskIndex));
+                taskIndex++;
+            }
+        }
+
+        internalList.setAll(associations);
+    }
+
+    /**
+     * Adds a listener to {@code roomList} to recreate all {@code RoomTaskAssociation} whenever
+     * there is a change.
+     *
+     * This ensures that the associations are properly synchronized and the task indexes are correct.
+     */
+    private void updateAssociationIfChanged(ObservableList<Room> roomList) {
         roomList.addListener(new ListChangeListener<Room>() {
             @Override
             public void onChanged(Change<? extends Room> change) {
                 while (change.next()) {
-                    if (change.wasRemoved()) {
-                        //caters to initroom
-                        ArrayList<Task> updatedTaskList = new ArrayList<>();
-                        for (Room room : roomList) {
-                            updatedTaskList.addAll(room.getReadOnlyTasks());
-                        }
-                        internalList.setAll(updatedTaskList);
-                    } else if (change.wasUpdated()) {
-                        //when there's a change, the changes in tasks room is added last
-                        int indexToChange = change.getFrom();
-                        Room changedRoom = change.getList().get(indexToChange);
-                        int roomNumber = changedRoom.getRoomNumber();
-                        ArrayList<Task> updatedTaskList = new ArrayList<>();
-                        for (Task task : internalList) {
-                        }
-                        updatedTaskList.addAll(changedRoom.getReadOnlyTasks());
-                        internalList.setAll(updatedTaskList);
+                    // Minor optimization; new rooms have no tasks and hence do not need associations to be refreshed
+                    if (!change.wasAdded()) {
+                        // Recreate all room-task assocations; caters to initroom
+                        createRoomTaskAssociations(roomList);
+                        logger.fine("Changes detected in Room #" + change.getFrom()
+                                + ". Updating room-task associations...");
                     }
                 }
             }
         });
     }
 
-    public ObservableList<Task> getReadOnlyList() {
+    @Override
+    public ObservableList<RoomTaskAssociation> getReadOnlyList() {
         return internalUnmodifiableList;
     }
 }

--- a/src/main/java/seedu/address/model/room/Room.java
+++ b/src/main/java/seedu/address/model/room/Room.java
@@ -119,14 +119,6 @@ public class Room {
     }
 
     /**
-     * Returns the room tasks in the room.
-     */
-    public RoomTasks getRoomTasks() {
-        return tasks;
-    }
-
-
-    /**
      * Returns the task with the provided {@code taskIndex} from this room.
      * An empty optional is returned if such a task is not found in the room.
      *

--- a/src/main/java/seedu/address/model/room/Room.java
+++ b/src/main/java/seedu/address/model/room/Room.java
@@ -5,10 +5,8 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
-import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.ReadOnlyList;
 import seedu.address.model.patient.Patient;
@@ -105,13 +103,6 @@ public class Room {
     }
 
     /**
-     * Returns a filtered list as an {@code FilteredList}.
-     */
-    public FilteredList<Task> getFilteredTasks() {
-        return tasks.getFilteredList();
-    }
-
-    /**
      * Returns an unmodifiable version of the list of tasks in this room as a {@code ReadOnlyList}.
      */
     public ReadOnlyList<Task> getReadOnlyList() {
@@ -176,13 +167,6 @@ public class Room {
         } catch (TaskNotFoundException e) {
             throw e;
         }
-    }
-
-    /**
-     * Sets the {@code predicate} to filter the tasks in this room.
-     */
-    public void setPredicateOnRoomTasks(Predicate<Task> predicate) {
-        tasks.setPredicate(predicate);
     }
 
     /**

--- a/src/main/java/seedu/address/model/room/RoomTaskAssociation.java
+++ b/src/main/java/seedu/address/model/room/RoomTaskAssociation.java
@@ -1,5 +1,7 @@
 package seedu.address.model.room;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
 import seedu.address.model.task.Task;
 
 /**
@@ -22,6 +24,8 @@ public class RoomTaskAssociation {
      * @param taskIndex The index of the task in the room.
      */
     public RoomTaskAssociation(Room room, Task task, int taskIndex) {
+        requireAllNonNull(room, task);
+        assert taskIndex > 0 : "Task index must be greater than 0.";
         this.room = room;
         this.task = task;
         this.taskIndex = taskIndex;
@@ -44,5 +48,21 @@ public class RoomTaskAssociation {
      */
     public int getTotalTasksInRoom() {
         return room.getReadOnlyTasks().size();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof RoomTaskAssociation)) {
+            return false;
+        }
+
+        RoomTaskAssociation otherRoomTaskAssociation = (RoomTaskAssociation) other;
+        return room.equals(otherRoomTaskAssociation.room)
+                && task.equals(otherRoomTaskAssociation.task)
+                && taskIndex == otherRoomTaskAssociation.taskIndex;
     }
 }

--- a/src/main/java/seedu/address/model/room/RoomTaskAssociation.java
+++ b/src/main/java/seedu/address/model/room/RoomTaskAssociation.java
@@ -1,0 +1,48 @@
+package seedu.address.model.room;
+
+import seedu.address.model.task.Task;
+
+/**
+ * An association class between {@code Room} and {@code Task}. This class serves 2 primary purposes:
+ * i) stores critical information related to {@code Room} (e.g. room number) to be displayed on the
+ * Task user interface without creating a direct association between {@code Room} and {@code Task}.
+ * ii) provides a convenient way to retrieve the index of a task in room in constant time.
+ */
+public class RoomTaskAssociation {
+
+    private final Room room;
+    private final Task task;
+    private final int taskIndex;
+
+    /**
+     * Creates an association between {@code room} and {@code task}.
+     *
+     * @param room The room in which the task is found.
+     * @param task The task.
+     * @param taskIndex The index of the task in the room.
+     */
+    public RoomTaskAssociation(Room room, Task task, int taskIndex) {
+        this.room = room;
+        this.task = task;
+        this.taskIndex = taskIndex;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public int getRoomNumber() {
+        return room.getRoomNumber();
+    }
+
+    public int getTaskIndex() {
+        return taskIndex;
+    }
+
+    /**
+     * Returns the total number of tasks in the room.
+     */
+    public int getTotalTasksInRoom() {
+        return room.getReadOnlyTasks().size();
+    }
+}

--- a/src/main/java/seedu/address/model/room/RoomTasks.java
+++ b/src/main/java/seedu/address/model/room/RoomTasks.java
@@ -5,10 +5,8 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
-import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.ReadOnlyList;
 import seedu.address.model.task.Task;
@@ -21,14 +19,12 @@ import seedu.address.model.task.TaskList;
 public class RoomTasks implements ReadOnlyList<Task> {
 
     private final TaskList tasks;
-    private final FilteredList<Task> filteredTaskList;
 
     /**
      * Creates an empty list of tasks in the room.
      */
     public RoomTasks() {
         tasks = new TaskList();
-        filteredTaskList = new FilteredList<>(tasks.asUnmodifiableObservableList());
     }
 
     /**
@@ -38,7 +34,6 @@ public class RoomTasks implements ReadOnlyList<Task> {
         requireAllNonNull(tasksToAdd);
         tasks = new TaskList();
         tasks.setTasks(tasksToAdd);
-        filteredTaskList = new FilteredList<>(tasks.asUnmodifiableObservableList());
     }
 
     //// task-level operations
@@ -98,23 +93,6 @@ public class RoomTasks implements ReadOnlyList<Task> {
      */
     public boolean isEmpty() {
         return tasks.isEmpty();
-    }
-
-    //// filtered-task operations
-
-    /**
-     * Returns the filtered list of tasks for this room.
-     */
-    public FilteredList<Task> getFilteredList() {
-        return filteredTaskList;
-    }
-
-    /**
-     * Sets the {@code predicate} to filter the tasks in this room.
-     */
-    public void setPredicate(Predicate<Task> predicate) {
-        requireNonNull(predicate);
-        filteredTaskList.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/room/UniqueRoomList.java
+++ b/src/main/java/seedu/address/model/room/UniqueRoomList.java
@@ -25,7 +25,7 @@ public class UniqueRoomList implements Iterable<Room> {
     private int numOfRooms;
     private PriorityQueue<Room> rooms = new PriorityQueue<>(new ComparableRoom());
     private final ObservableList<Room> internalList = FXCollections.observableArrayList((Room room) -> {
-        Observable[] updatedTasks = new Observable[]{room.getFilteredTasks()};
+        Observable[] updatedTasks = new Observable[]{room.getReadOnlyTasks()};
         return updatedTasks;
     });
     private final ObservableList<Room> internalUnmodifiableList =

--- a/src/main/java/seedu/address/model/room/UniqueRoomList.java
+++ b/src/main/java/seedu/address/model/room/UniqueRoomList.java
@@ -278,7 +278,7 @@ public class UniqueRoomList implements Iterable<Room> {
             if (patientName.equals(patientNameInRoom)) {
                 Room roomToClear = internalList.get(i - 1);
                 setSingleRoom(roomToClear, new Room(roomToClear.getRoomNumber(),
-                        false, Optional.empty(), roomToClear.getRoomTasks()));
+                        false, Optional.empty(), new RoomTasks(roomToClear.getReadOnlyTasks())));
                 break;
             }
         }

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -6,8 +6,7 @@ import java.util.Objects;
 
 //@@author w-yeehong
 /**
- * Represents a Task that can be assigned to a room. The task room number must strictly follow
- * the room number of the room that the task is assigned to.
+ * Represents a Task that can be assigned to a room.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Task {
@@ -15,16 +14,14 @@ public class Task {
     // Data fields (i.e. values entered by user).
     private final Description description;
     private final DateTimeDue dueAt;
-    private final int taskRoomNumber;
 
     /**
      * Every field apart must be present and not null.
      */
-    public Task(Description description, DateTimeDue dueAt, int taskRoomNumber) {
-        requireAllNonNull(description, dueAt, taskRoomNumber);
+    public Task(Description description, DateTimeDue dueAt) {
+        requireAllNonNull(description, dueAt);
         this.description = description;
         this.dueAt = dueAt;
-        this.taskRoomNumber = taskRoomNumber;
     }
 
     public Description getDescription() {
@@ -33,10 +30,6 @@ public class Task {
 
     public DateTimeDue getDueAt() {
         return dueAt;
-    }
-
-    public int getTaskRoomNumber() {
-        return taskRoomNumber;
     }
 
     /**
@@ -54,8 +47,7 @@ public class Task {
 
         Task otherTask = (Task) other;
         return otherTask.getDescription().equals(getDescription())
-                && otherTask.getDueAt().equals(getDueAt())
-                && otherTask.getTaskRoomNumber() == getTaskRoomNumber();
+                && otherTask.getDueAt().equals(getDueAt());
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -20,18 +20,15 @@ public class JsonAdaptedTask {
 
     private String description;
     private String dueAt;
-    private int taskRoomNumber;
 
     /**
      * Constructs a {@code JsonAdaptedTask} with the given Task details.
      */
     @JsonCreator
     public JsonAdaptedTask(@JsonProperty("description") String description,
-                           @JsonProperty("dueAt") String dueAt,
-                           @JsonProperty("roomNumber") int taskRoomNumber) throws IllegalValueException {
+                           @JsonProperty("dueAt") String dueAt) throws IllegalValueException {
         this.description = description;
         this.dueAt = dueAt;
-        this.taskRoomNumber = taskRoomNumber;
     }
 
     /**
@@ -40,7 +37,6 @@ public class JsonAdaptedTask {
     public JsonAdaptedTask(Task source) {
         this.description = source.getDescription().value;
         this.dueAt = source.getDueAt().getVal();
-        this.taskRoomNumber = source.getTaskRoomNumber();
     }
 
     /**
@@ -59,6 +55,6 @@ public class JsonAdaptedTask {
         } catch (IllegalArgumentException i) {
             throw new IllegalValueException(DATE_WRONG_FORMAT);
         }
-        return new Task(new Description(description), dateTimeDue, taskRoomNumber);
+        return new Task(new Description(description), dateTimeDue);
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -143,7 +143,7 @@ public class MainWindow extends UiPart<Stage> {
         roomListPanel = new RoomListPanel(logic.getFilteredRoomList());
         roomListPanelPlaceHolder.getChildren().add(roomListPanel.getRoot());
 
-        roomTaskListPanel = new RoomTaskListPanel(logic.getFilteredTaskList());
+        roomTaskListPanel = new RoomTaskListPanel(logic.getFilteredRoomTaskRecords());
         taskListPanelPlaceholder.getChildren().add(roomTaskListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();

--- a/src/main/java/seedu/address/ui/RoomTaskListPanel.java
+++ b/src/main/java/seedu/address/ui/RoomTaskListPanel.java
@@ -73,7 +73,7 @@ public class RoomTaskListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                int roomNumber = task.getTaskRoomNumber();
+                int roomNumber = 1; // temporary placeholder
                 setGraphic(new TaskCard(roomNumber, task)
                         .getRoot());
             }

--- a/src/main/java/seedu/address/ui/RoomTaskListPanel.java
+++ b/src/main/java/seedu/address/ui/RoomTaskListPanel.java
@@ -2,16 +2,13 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.core.index.Index;
-import seedu.address.model.task.Task;
+import seedu.address.model.room.RoomTaskAssociation;
 
 /**
  * Panel containing the list of room with tasks.
@@ -23,59 +20,35 @@ public class RoomTaskListPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(RoomTaskListPanel.class);
 
     @FXML
-    private ScrollPane roomScrollPane;
-    @FXML
-    private ListView<Task> taskListView;
+    private ListView<RoomTaskAssociation> roomTaskListView;
 
     /**
      * Creates a {@code RoomTaskListPanel} with the given {@code ObservableList}.
      */
-    public RoomTaskListPanel(ObservableList<Task> roomTaskList) {
+    public RoomTaskListPanel(ObservableList<RoomTaskAssociation> roomTaskAssociations) {
         super(FXML);
-        updateDetailsIfChanged(roomTaskList);
-        taskListView.setItems(roomTaskList);
-        taskListView.setCellFactory(listView -> new TaskListViewCell());
-        updateDetailsIfChanged(roomTaskList);
-        logger.info("RoomTaskListPanel has been filled.");
+        roomTaskListView.setItems(roomTaskAssociations);
+        roomTaskListView.setCellFactory(listView -> new RoomTaskListViewCell());
+        logger.info("RoomTaskListPanel has been initialized with tasks from all rooms.");
     }
 
-    //@@author w-yeehong
     /**
-     * Attaches a listener to {@code roomTaskList}.
-     *
-     * @param roomTaskList The task list to listen to for changes.
+     * Custom {@code ListCell} that displays the graphics of a {@code RoomTaskAssociation} using a {@code TaskCard}.
      */
-    private void updateDetailsIfChanged(ObservableList<Task> roomTaskList) {
-        roomTaskList.addListener(new ListChangeListener<Task>() {
-            @Override
-            public void onChanged(Change<? extends Task> change) {
-                while (change.next()) {
-                    int indexOfChange = change.getFrom();
-                    Index index = Index.fromZeroBased(indexOfChange);
-                    logger.info("Changes detected in Task " + index.getOneBased()
-                            + ". Updating RoomTaskListPanel...");
-                    taskListView.setCellFactory(listView -> new TaskListViewCell());
-                }
-            }
-        });
-    }
-    //@@author w-yeehong
-
-    /**
-     * Custom {@code ListCell} that displays the graphics of a {@code Task} using a {@code TaskCard}.
-     */
-    class TaskListViewCell extends ListCell<Task> {
+    class RoomTaskListViewCell extends ListCell<RoomTaskAssociation> {
         @Override
-        protected void updateItem(Task task, boolean empty) {
-            super.updateItem(task, empty);
+        protected void updateItem(RoomTaskAssociation roomTaskAssociation, boolean empty) {
+            super.updateItem(roomTaskAssociation, empty);
 
-            if (empty || task == null) {
+            if (empty || roomTaskAssociation == null) {
                 setGraphic(null);
                 setText(null);
             } else {
-                int roomNumber = 1; // temporary placeholder
-                setGraphic(new TaskCard(roomNumber, task)
-                        .getRoot());
+                int roomNumber = roomTaskAssociation.getRoomNumber();
+                int taskIndex = roomTaskAssociation.getTaskIndex();
+                int totalNumberOfTasksInRoom = roomTaskAssociation.getTotalTasksInRoom();
+                setGraphic(new TaskCard(roomNumber, taskIndex, totalNumberOfTasksInRoom,
+                        roomTaskAssociation.getTask()).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -15,15 +15,20 @@ public class TaskCard extends UiPart<Region> {
     private static final String FXML = "TaskListCard.fxml";
 
     public final int roomNumber;
+    public final int taskIndex;
+    public final int totalNumberOfTasksInRoom;
     public final Task task;
 
     private final String roomIdText = "[Room %1$d]";
+    private final String taskIdText = "Task %1$d of %2$d";
     private final String dueAtText = "Due Date: %1$s";
 
     @FXML
     private HBox cardPane;
     @FXML
     private Label roomId;
+    @FXML
+    private Label taskId;
     @FXML
     private TextField description;
     @FXML
@@ -35,9 +40,11 @@ public class TaskCard extends UiPart<Region> {
      * @param roomNumber The room number of the room in which the task is found.
      * @param task The task.
      */
-    public TaskCard(int roomNumber, Task task) {
+    public TaskCard(int roomNumber, int taskIndex, int totalNumberOfTasksInRoom, Task task) {
         super(FXML);
         this.roomNumber = roomNumber;
+        this.taskIndex = taskIndex;
+        this.totalNumberOfTasksInRoom = totalNumberOfTasksInRoom;
         this.task = task;
         setTaskCard(task);
     }
@@ -49,6 +56,7 @@ public class TaskCard extends UiPart<Region> {
      */
     private void setTaskCard(Task task) {
         roomId.setText(String.format(roomIdText, roomNumber));
+        taskId.setText(String.format(taskIdText, taskIndex, totalNumberOfTasksInRoom));
         description.setText(task.getDescription().toString());
         dueAt.setText(String.format(dueAtText, task.getDueAt().toString()));
     }
@@ -67,6 +75,8 @@ public class TaskCard extends UiPart<Region> {
 
         // state check
         return roomNumber == ((TaskCard) other).roomNumber
+                && taskIndex == ((TaskCard) other).taskIndex
+                && totalNumberOfTasksInRoom == ((TaskCard) other).totalNumberOfTasksInRoom
                 && task.equals(((TaskCard) other).task);
     }
 }

--- a/src/main/resources/css/ListPanelNoHighlights.css
+++ b/src/main/resources/css/ListPanelNoHighlights.css
@@ -1,0 +1,23 @@
+.list-view {
+    -fx-background-insets: 0;
+    -fx-padding: 0;
+    -fx-background-color: #aec6cf;
+}
+
+.list-cell {
+    -fx-label-padding: 0 0 0 0;
+    -fx-graphic-text-gap : 0;
+    -fx-padding: 0 0 0 0;
+}
+
+.list-cell:filled:even {
+    -fx-background-color: #fff1f1;
+}
+
+.list-cell:filled:odd {
+    -fx-background-color: derive(#fff1f1, 20%);
+}
+
+.list-cell .label {
+    -fx-text-fill: #000000;
+}

--- a/src/main/resources/view/RoomTaskListPanel.fxml
+++ b/src/main/resources/view/RoomTaskListPanel.fxml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<?import javafx.scene.control.ListView?>
-<ScrollPane fx:id="roomScrollPane" fitToWidth="true" stylesheets="@../css/ListPanel.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <content>
-    <VBox>
-      <ListView fx:id="taskListView" />
-    </VBox>
-  </content>
-</ScrollPane>
+<VBox stylesheets="@../css/ListPanel.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <ListView fx:id="roomTaskListView" />
+</VBox>

--- a/src/main/resources/view/RoomTaskListPanel.fxml
+++ b/src/main/resources/view/RoomTaskListPanel.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox stylesheets="@../css/ListPanel.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox stylesheets="@../css/ListPanelNoHighlights.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <ListView fx:id="roomTaskListView" />
 </VBox>

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -26,6 +26,7 @@
           </minWidth>
         <TextField fx:id="description" styleClass="text-field" editable="false" HBox.hgrow="ALWAYS"/>
       </HBox>
+      <Label fx:id="taskId" styleClass="label-small" GridPane.columnIndex="0" />
       <Label fx:id="dueAt" styleClass="label-small" GridPane.columnIndex="1" />
     </VBox>
   </GridPane>

--- a/src/test/data/JsonSerializableRoomListTest/notCorrectStartRooms.json
+++ b/src/test/data/JsonSerializableRoomListTest/notCorrectStartRooms.json
@@ -83,7 +83,7 @@
 "patient": null,
 "tasks": {
 "tasks": [{"description": "Room #1 is running low on masks and needs to be restocked.",
-"dueAt": "20200925", "roomNumber": "11"}]
+"dueAt": "20200925"}]
 }
 },{
 "roomNumber" : 12,

--- a/src/test/data/JsonSerializableRoomListTest/typicalRoomsInRoomList.json
+++ b/src/test/data/JsonSerializableRoomListTest/typicalRoomsInRoomList.json
@@ -91,8 +91,7 @@
       "patient": null,
       "tasks": {
         "tasks": [{"description": "Room #1 is running low on masks and needs to be restocked.",
-          "dueAt": "20200925",
-          "roomNumber": "11"}]
+          "dueAt": "20200925"}]
       }
     },{
       "roomNumber" : 12,

--- a/src/test/data/JsonSerializableTaskListTest/typicalTasksInTaskList.json
+++ b/src/test/data/JsonSerializableTaskListTest/typicalTasksInTaskList.json
@@ -1,15 +1,12 @@
 {
   "tasks" : [ {
     "description" : "Remind Alice to change bedsheets.",
-    "dueAt" : "20201230 2359",
-    "roomNumber": "2"
+    "dueAt" : "20201230 2359"
   }, {
     "description" : "Room #1 is running low on masks and needs to be restocked.",
-    "dueAt" : "20200925",
-    "roomNumber": "1"
+    "dueAt" : "20200925"
   }, {
     "description" : "Call the U.S. embassy for Bob.",
-    "dueAt" : "20201014 1800",
-    "roomNumber": "3"
+    "dueAt" : "20201014 1800"
   } ]
 }

--- a/src/test/java/seedu/address/logic/parser/task/AddTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/AddTaskCommandParserTest.java
@@ -36,7 +36,7 @@ public class AddTaskCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Task expectedTask = new TaskBuilder(REMIND_PATIENT).withRoomNumber(7).build();
+        Task expectedTask = new TaskBuilder(REMIND_PATIENT).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + DESCRIPTION_DESC_REMIND_PATIENT + ROOM_NUMBER_SEVEN_DESC
@@ -61,8 +61,7 @@ public class AddTaskCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // no due date
-        Task expectedTask = new TaskBuilder(REMIND_PATIENT).withDateTimeDue(Optional.empty())
-                .withRoomNumber(7).build();
+        Task expectedTask = new TaskBuilder(REMIND_PATIENT).withDateTimeDue(Optional.empty()).build();
         assertParseSuccess(parser, DESCRIPTION_DESC_REMIND_PATIENT + ROOM_NUMBER_SEVEN_DESC,
                 new AddTaskCommand(expectedTask, VALID_ROOM_NUMBER_SEVEN));
     }

--- a/src/test/java/seedu/address/model/room/RoomTaskAssociationTest.java
+++ b/src/test/java/seedu/address/model/room/RoomTaskAssociationTest.java
@@ -1,0 +1,69 @@
+package seedu.address.model.room;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalRooms.ROOM_NO_PATIENT_TASK_RESTOCK_SUPPLY;
+import static seedu.address.testutil.TypicalRooms.ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT;
+import static seedu.address.testutil.TypicalTasks.REMIND_PATIENT;
+import static seedu.address.testutil.TypicalTasks.RESTOCK_SUPPLY;
+
+import org.junit.jupiter.api.Test;
+
+public class RoomTaskAssociationTest {
+
+    private final RoomTaskAssociation roomTaskAssociation =
+            new RoomTaskAssociation(ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT, REMIND_PATIENT, 1);
+
+    @Test
+    public void constructor_nullRoom_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new RoomTaskAssociation(null, REMIND_PATIENT, 1));
+    }
+
+    @Test
+    public void constructor_nullTask_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new RoomTaskAssociation(ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT, null, 1));
+    }
+
+    @Test
+    public void constructor_taskIndexLesserThanOne_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> new RoomTaskAssociation(ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT,
+                REMIND_PATIENT, 0));
+
+        assertThrows(AssertionError.class, () -> new RoomTaskAssociation(ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT,
+                REMIND_PATIENT, -1));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        RoomTaskAssociation roomTaskAssociationCopy = new RoomTaskAssociation(
+                ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT, REMIND_PATIENT, 1);
+        assertTrue(roomTaskAssociation.equals(roomTaskAssociationCopy));
+
+        // same object -> returns true
+        assertTrue(roomTaskAssociation.equals(roomTaskAssociation));
+
+        // null -> returns false
+        assertFalse(roomTaskAssociation.equals(null));
+
+        // different type -> returns false
+        assertFalse(roomTaskAssociation.equals(5));
+
+        // different room -> returns false
+        RoomTaskAssociation roomTaskAssociationDifferentRoom = new RoomTaskAssociation(
+                ROOM_NO_PATIENT_TASK_RESTOCK_SUPPLY, REMIND_PATIENT, 1);
+        assertFalse(roomTaskAssociation.equals(roomTaskAssociationDifferentRoom));
+
+        // different task -> returns false
+        RoomTaskAssociation roomTaskAssociationDifferentTask = new RoomTaskAssociation(
+                ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT, RESTOCK_SUPPLY, 1);
+        assertFalse(roomTaskAssociation.equals(roomTaskAssociationDifferentTask));
+
+        // different task index -> returns false
+        RoomTaskAssociation roomTaskAssociationDifferentTaskIndex = new RoomTaskAssociation(
+                ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT, REMIND_PATIENT, 2);
+        assertFalse(roomTaskAssociation.equals(roomTaskAssociationDifferentTaskIndex));
+    }
+}

--- a/src/test/java/seedu/address/model/room/RoomTasksTest.java
+++ b/src/test/java/seedu/address/model/room/RoomTasksTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static seedu.address.testutil.TypicalTasks.REMIND_PATIENT;
 import static seedu.address.testutil.TypicalTasks.RESTOCK_SUPPLY;
-import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DESCRIPTION_REMIND_PATIENT;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -25,7 +24,6 @@ public class RoomTasksTest {
     @Test
     public void constructor() {
         assertEquals(Collections.emptyList(), roomTasks.getReadOnlyList());
-        assertEquals(Collections.emptyList(), roomTasks.getFilteredList());
     }
 
     @Test
@@ -49,25 +47,6 @@ public class RoomTasksTest {
         roomTasks.addTask(REMIND_PATIENT);
         Optional<Task> optionalTask = roomTasks.getTaskWithTaskIndex(index);
         assertEquals(Optional.of(REMIND_PATIENT), optionalTask);
-    }
-
-    @Test
-    public void setPredicate_nullPredicate_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> roomTasks.setPredicate(null));
-    }
-
-    @Test
-    public void setPredicate_validPredicate_roomTasksFiltered() {
-        roomTasks.addTask(REMIND_PATIENT);
-        roomTasks.addTask(RESTOCK_SUPPLY);
-
-        // invalid description -> empty filtered list
-        roomTasks.setPredicate(task -> task.getDescription().value.equals("invalid description"));
-        assertEquals(Collections.emptyList(), roomTasks.getFilteredList());
-
-        // valid description for REMIND_PATIENT -> filtered list contains only REMIND_PATIENT
-        roomTasks.setPredicate(task -> task.getDescription().value.equals(VALID_DESCRIPTION_REMIND_PATIENT));
-        assertEquals(Collections.singletonList(REMIND_PATIENT), roomTasks.getFilteredList());
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedRoomTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedRoomTest.java
@@ -62,7 +62,7 @@ class JsonAdaptedRoomTest {
 
     @Test
     public void toModelType_invalidDueDate_throwsIllegalValueException() throws Exception {
-        JsonAdaptedTask task = new JsonAdaptedTask(VALID_DESCRIPTION, INVALID_DUE_DATE, VALID_ROOM_NUM);
+        JsonAdaptedTask task = new JsonAdaptedTask(VALID_DESCRIPTION, INVALID_DUE_DATE);
         List<JsonAdaptedTask> tasks = new ArrayList<>();
         tasks.add(task);
         JsonSerializableTaskList taskList = new JsonSerializableTaskList(tasks);
@@ -75,7 +75,7 @@ class JsonAdaptedRoomTest {
 
     @Test
     public void toModelType_invalidPatient_throwsIllegalValueException() throws Exception {
-        JsonAdaptedTask task = new JsonAdaptedTask(VALID_DESCRIPTION, VALID_DUE_DATE, VALID_ROOM_NUM);
+        JsonAdaptedTask task = new JsonAdaptedTask(VALID_DESCRIPTION, VALID_DUE_DATE);
         List<JsonAdaptedTask> tasks = new ArrayList<>();
         tasks.add(task);
         JsonSerializableTaskList taskList = new JsonSerializableTaskList(tasks);

--- a/src/test/java/seedu/address/storage/JsonAdaptedTaskTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedTaskTest.java
@@ -16,7 +16,6 @@ import seedu.address.testutil.Assert;
 class JsonAdaptedTaskTest {
     public static final String VALID_DESCRIPTION = REMIND_PATIENT.getDescription().value;
     public static final String INVALID_DUE_DATE = "two thirty";
-    public static final int VALID_ROOM_NUMBER = 3;
 
     @Test
     public void toModelType_success_remindPatient() throws Exception {
@@ -39,7 +38,7 @@ class JsonAdaptedTaskTest {
 
     @Test
     public void toModelType_invalidDueDate_throwsIllegalValueException() throws IllegalValueException {
-        JsonAdaptedTask task = new JsonAdaptedTask(VALID_DESCRIPTION, INVALID_DUE_DATE, VALID_ROOM_NUMBER);
+        JsonAdaptedTask task = new JsonAdaptedTask(VALID_DESCRIPTION, INVALID_DUE_DATE);
         String expectedMessage = JsonAdaptedTask.DATE_WRONG_FORMAT;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, task::toModelType);
     }

--- a/src/test/java/seedu/address/testutil/TaskBuilder.java
+++ b/src/test/java/seedu/address/testutil/TaskBuilder.java
@@ -13,11 +13,9 @@ public class TaskBuilder {
 
     public static final String DEFAULT_DESCRIPTION = "Remind John to clean bedsheets.";
     public static final String DEFAULT_DATETIME_DUE = "20201014 2359";
-    public static final int DEFAULT_TASK_ROOM_NUM = 7;
 
     private Description description;
     private DateTimeDue dueAt;
-    private int taskRoomNumber;
 
     /**
      * Creates a {@code TaskBuilder} with the default details.
@@ -25,7 +23,6 @@ public class TaskBuilder {
     public TaskBuilder() {
         description = new Description(DEFAULT_DESCRIPTION);
         dueAt = new DateTimeDue(DEFAULT_DATETIME_DUE);
-        taskRoomNumber = DEFAULT_TASK_ROOM_NUM;
     }
 
     /**
@@ -34,7 +31,6 @@ public class TaskBuilder {
     public TaskBuilder(Task taskToCopy) {
         description = taskToCopy.getDescription();
         dueAt = taskToCopy.getDueAt();
-        taskRoomNumber = taskToCopy.getTaskRoomNumber();
     }
 
     /**
@@ -53,15 +49,7 @@ public class TaskBuilder {
         return this;
     }
 
-    /**
-     * Sets the {@code task room number} of the {@Task} that we are building.
-     */
-    public TaskBuilder withRoomNumber(int roomNumber) {
-        this.taskRoomNumber = roomNumber;
-        return this;
-    }
-
     public Task build() {
-        return new Task(description, dueAt, taskRoomNumber);
+        return new Task(description, dueAt);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalRooms.java
+++ b/src/test/java/seedu/address/testutil/TypicalRooms.java
@@ -32,7 +32,7 @@ public class TypicalRooms {
             .withIsOccupied(false).withPatient(null).build();
     public static final Room ROOM_NO_PATIENT_TASK_RESTOCK_SUPPLY = new RoomBuilder()
             .withIsOccupied(false).withPatient(null).withRoomNumber(ROOM_NUMBER_11)
-            .withTasks(new TaskBuilder(RESTOCK_SUPPLY).withRoomNumber(11).build()).build();
+            .withTasks(RESTOCK_SUPPLY).build();
     public static final Room ROOM_PATIENT_ALICE_NO_TASK = new RoomBuilder()
             .withIsOccupied(true).withPatient(ALICE).build();
     public static final Room ROOM_PATIENT_ALICE_TASK_REMIND_PATIENT = new RoomBuilder()

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -17,16 +17,13 @@ public class TypicalTasks {
 
     public static final Task REMIND_PATIENT = new TaskBuilder()
             .withDescription("Remind Alice to change bedsheets.")
-            .withDateTimeDue(Optional.of("20201230 2359"))
-            .withRoomNumber(2).build();
+            .withDateTimeDue(Optional.of("20201230 2359")).build();
     public static final Task RESTOCK_SUPPLY = new TaskBuilder()
             .withDescription("Room #1 is running low on masks and needs to be restocked.")
-            .withDateTimeDue(Optional.of("20200925"))
-            .withRoomNumber(1).build();
+            .withDateTimeDue(Optional.of("20200925")).build();
     public static final Task CALL_EMBASSY = new TaskBuilder()
             .withDescription("Call the U.S. embassy for Bob.")
-            .withDateTimeDue(Optional.of("20201014 1800"))
-            .withRoomNumber(3).build();
+            .withDateTimeDue(Optional.of("20201014 1800")).build();
 
     // Manually added
     public static final Task FIX_SHOWER = new TaskBuilder()

--- a/src/test/java/seedu/address/testutil/stubs/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/stubs/ModelStub.java
@@ -213,7 +213,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void updateFilteredTaskList(Predicate<Task> datePredicate) {
+    public void updateTasksInFilteredRoomTaskRecords(Predicate<Task> taskPredicate) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/testutil/stubs/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/stubs/ModelStub.java
@@ -15,6 +15,7 @@ import seedu.address.model.RoomList;
 import seedu.address.model.patient.Name;
 import seedu.address.model.patient.Patient;
 import seedu.address.model.room.Room;
+import seedu.address.model.room.RoomTaskAssociation;
 import seedu.address.model.task.Task;
 
 /**
@@ -68,6 +69,16 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void setRoomList(ReadOnlyList<Room> rooms) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyList<RoomTaskAssociation> getRoomTaskRecords() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public boolean hasPatient(Patient patient) {
         throw new AssertionError("This method should not be called.");
     }
@@ -104,11 +115,6 @@ public class ModelStub implements Model {
 
     @Override
     public void updateFilteredPatientList(Predicate<Patient> predicate) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public void setRoomList(ReadOnlyList<Room> rooms) {
         throw new AssertionError("This method should not be called.");
     }
 
@@ -212,7 +218,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public ObservableList<Task> getFilteredTaskList() {
+    public ObservableList<RoomTaskAssociation> getFilteredRoomTaskRecords() {
         throw new AssertionError("This method should not be called.");
     }
 


### PR DESCRIPTION
1. Using an association class `RoomTaskAssociation`, I restored the task index to the task UI. 
1. This PR also fixes the issue where a user can modify the room number of a task in the `.json` file to cause data inconsistencies.

Credits to @chiamyunqing for setting up the base for this solution and to @LeeMingDe for setting up the extractor for `ObservableList<Room>` to listen to changes in tasks.