### PR TITLE
Add unit tests for task-related commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
@@ -52,14 +52,12 @@ public class AddTaskCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        if (roomNumber < 0) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ROOM_NUMBER);
-        }
 
         Optional<Room> optionalRoom = model.getRoomWithRoomNumber(roomNumber);
+        assert optionalRoom != null : "The return value from Model#getRoomWithRoomNumber(...) should never be null.";
+
         Room room = optionalRoom.orElseThrow(() ->
                 new CommandException(Messages.MESSAGE_INVALID_ROOM_NUMBER));
-        assert room != null : "Target room should never be null.";
 
         model.addTaskToRoom(taskToAdd, room);
         return new CommandResult(String.format(MESSAGE_ADD_TASK_SUCCESS,

--- a/src/main/java/seedu/address/logic/commands/task/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/DeleteTaskCommand.java
@@ -53,21 +53,19 @@ public class DeleteTaskCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        if (roomNumber < 0) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ROOM_NUMBER);
-        }
 
         // Get the room from which the user wants to delete the task
         Optional<Room> optionalRoom = model.getRoomWithRoomNumber(roomNumber);
+        assert optionalRoom != null : "The return value from Model#getRoomWithRoomNumber(...) should never be null.";
         Room room = optionalRoom.orElseThrow(() ->
                 new CommandException(Messages.MESSAGE_INVALID_ROOM_NUMBER));
-        assert room != null : "Target room should never be null.";
 
         // Get the task which the user wants to delete
         Optional<Task> optionalTask = model.getTaskFromRoomWithTaskIndex(taskIndex, room);
+        assert optionalTask != null : "The return value from Model#getTaskFromRoomWithTaskIndex(...)"
+                + " should not be null.";
         Task taskToDelete = optionalTask.orElseThrow(() ->
                 new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX));
-        assert taskToDelete != null : "The task to delete should never be null.";
 
         model.deleteTaskFromRoom(taskToDelete, room);
         return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS,

--- a/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
@@ -66,21 +66,19 @@ public class EditTaskCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        if (roomNumber < 0) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ROOM_NUMBER);
-        }
 
         // Get the room from which the user wants to delete the task
         Optional<Room> optionalRoom = model.getRoomWithRoomNumber(roomNumber);
+        assert optionalRoom != null : "The return value from Model#getRoomWithRoomNumber(...) should never be null.";
         Room room = optionalRoom.orElseThrow(() ->
                 new CommandException(Messages.MESSAGE_INVALID_ROOM_NUMBER));
-        assert room != null : "Target room should never be null.";
 
         // Get the task which the user wants to edit
         Optional<Task> optionalTask = model.getTaskFromRoomWithTaskIndex(taskIndex, room);
+        assert optionalTask != null : "The return value from Model#getTaskFromRoomWithTaskIndex(...)"
+                + " should not be null.";
         Task taskToEdit = optionalTask.orElseThrow(() ->
                 new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX));
-        assert taskToEdit != null : "The task to edit should never be null.";
 
         Task editedTask = createEditedTask(taskToEdit, editTaskDescriptor);
         if (taskToEdit.equals(editedTask)) {

--- a/src/test/java/seedu/address/logic/commands/task/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/AddTaskCommandTest.java
@@ -1,16 +1,39 @@
 package seedu.address.logic.commands.task;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalTasks.REMIND_PATIENT;
 import static seedu.address.testutil.TypicalTasks.RESTOCK_SUPPLY;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMBER_EIGHT;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMBER_SEVEN;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.room.Room;
+import seedu.address.testutil.RoomBuilder;
+
+//@@author w-yeehong
 public class AddTaskCommandTest {
+
+    private Model modelMock;
+
+    @BeforeEach
+    public void setUp() {
+        modelMock = mock(Model.class);
+    }
 
     @Test
     public void constructor_nullTask_throwsNullPointerException() {
@@ -18,11 +41,41 @@ public class AddTaskCommandTest {
     }
 
     @Test
-    public void constructor_nullRoomIndex_throwsNullPointerException() {
-        assertThrows(AssertionError.class, () -> new AddTaskCommand(REMIND_PATIENT, -1));
+    public void constructor_negativeRoomNumber_throwsAssertionError() {
+        int negativeRoomNumber = -1;
+        assertThrows(AssertionError.class, () -> new AddTaskCommand(REMIND_PATIENT, negativeRoomNumber));
     }
 
-    // TODO: set up RoomList and Model stubs for testing
+    @Test
+    public void execute_getRoomWithRoomNumberReturnsNull_throwsAssertionError() {
+        when(modelMock.getRoomWithRoomNumber(anyInt())).thenReturn(null);
+
+        AddTaskCommand addTaskCommand = new AddTaskCommand(REMIND_PATIENT, VALID_ROOM_NUMBER_SEVEN);
+
+        assertThrows(AssertionError.class, () -> addTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_roomWithRoomNumberNotInModel_throwsCommandException() {
+        when(modelMock.getRoomWithRoomNumber(anyInt())).thenReturn(Optional.empty());
+
+        AddTaskCommand addTaskCommand = new AddTaskCommand(REMIND_PATIENT, VALID_ROOM_NUMBER_SEVEN);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_ROOM_NUMBER, () ->
+                addTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_taskAcceptedByModel_addSuccessful() throws Exception {
+        Room validRoom = new RoomBuilder().withRoomNumber(VALID_ROOM_NUMBER_SEVEN).build();
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+
+        CommandResult commandResult = new AddTaskCommand(REMIND_PATIENT, VALID_ROOM_NUMBER_SEVEN).execute(modelMock);
+
+        verify(modelMock).addTaskToRoom(REMIND_PATIENT, validRoom);
+        assertEquals(String.format(AddTaskCommand.MESSAGE_ADD_TASK_SUCCESS, VALID_ROOM_NUMBER_SEVEN, REMIND_PATIENT),
+                commandResult.getFeedbackToUser());
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/task/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/DeleteTaskCommandTest.java
@@ -1,20 +1,113 @@
 package seedu.address.logic.commands.task;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalRooms.ROOM_NO_PATIENT_TASK_RESTOCK_SUPPLY;
+import static seedu.address.testutil.TypicalTasks.RESTOCK_SUPPLY;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMBER_EIGHT;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMBER_SEVEN;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_TASK_INDEX_ONE;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_TASK_INDEX_TWO;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.room.Room;
+import seedu.address.testutil.RoomBuilder;
+
+//@@author w-yeehong
 public class DeleteTaskCommandTest {
+
+    private Model modelMock;
+    private Room validRoom;
+
+    @BeforeEach
+    public void setUp() {
+        modelMock = mock(Model.class);
+        validRoom = new RoomBuilder(ROOM_NO_PATIENT_TASK_RESTOCK_SUPPLY)
+                .withRoomNumber(VALID_ROOM_NUMBER_SEVEN).build();
+    }
 
     @Test
     public void constructor_nullTaskIndex_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new DeleteTaskCommand(VALID_ROOM_NUMBER_SEVEN, null));
+    }
+
+    @Test
+    public void constructor_negativeRoomNumber_throwsAssertionError() {
+        int negativeRoomNumber = -1;
+        assertThrows(AssertionError.class, () -> new DeleteTaskCommand(negativeRoomNumber, VALID_TASK_INDEX_ONE));
+    }
+
+    @Test
+    public void execute_getRoomWithRoomNumberReturnsNull_throwsAssertionError() {
+        when(modelMock.getRoomWithRoomNumber(anyInt())).thenReturn(null);
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(RESTOCK_SUPPLY));
+
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE);
+
+        assertThrows(AssertionError.class, () -> deleteTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_getTaskFromRoomWithTaskIndexReturnsNull_throwsAssertionError() {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom)).thenReturn(null);
+
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE);
+
+        assertThrows(AssertionError.class, () -> deleteTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_roomWithRoomNumberNotInModel_throwsCommandException() {
+        when(modelMock.getRoomWithRoomNumber(anyInt())).thenReturn(Optional.empty());
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(RESTOCK_SUPPLY));
+
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_ROOM_NUMBER, () ->
+                deleteTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_taskWithTaskIndexNotInRoom_throwsCommandException() {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.empty());
+
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_TASK_INDEX, () ->
+                deleteTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_taskAcceptedByModel_deleteSuccessful() throws Exception {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(RESTOCK_SUPPLY));
+
+        CommandResult commandResult = new DeleteTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE)
+                .execute(modelMock);
+
+        verify(modelMock).deleteTaskFromRoom(RESTOCK_SUPPLY, validRoom);
+        assertEquals(String.format(DeleteTaskCommand.MESSAGE_DELETE_TASK_SUCCESS, VALID_TASK_INDEX_ONE.getOneBased(),
+                VALID_ROOM_NUMBER_SEVEN, RESTOCK_SUPPLY), commandResult.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/task/EditTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/EditTaskCommandTest.java
@@ -1,27 +1,62 @@
 package seedu.address.logic.commands.task;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static seedu.address.logic.commands.task.EditTaskCommand.EditTaskDescriptor;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalRooms.ROOM_NO_PATIENT_TASK_RESTOCK_SUPPLY;
+import static seedu.address.testutil.TypicalTasks.REMIND_PATIENT;
+import static seedu.address.testutil.TypicalTasks.RESTOCK_SUPPLY;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMBER_EIGHT;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMBER_SEVEN;
+import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DATETIME_DUE_ORDER_BEDSHEET;
+import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DATETIME_DUE_REMIND_PATIENT;
+import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DESCRIPTION_ORDER_BEDSHEET;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DESCRIPTION_REMIND_PATIENT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_TASK_INDEX_ONE;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_TASK_INDEX_TWO;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.room.Room;
+import seedu.address.model.task.DateTimeDue;
 import seedu.address.model.task.Description;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.RoomBuilder;
+import seedu.address.testutil.TaskBuilder;
 
+//@@author w-yeehong
 public class EditTaskCommandTest {
 
     private EditTaskDescriptor descriptor;
+    private Model modelMock;
+    private Room validRoom;
 
     @BeforeEach
     public void setUp() {
         descriptor = new EditTaskDescriptor();
+        modelMock = mock(Model.class);
+        validRoom = new RoomBuilder(ROOM_NO_PATIENT_TASK_RESTOCK_SUPPLY)
+                .withRoomNumber(VALID_ROOM_NUMBER_SEVEN).build();
+    }
+
+    @Test
+    public void constructor_negativeRoomNumber_throwsAssertionError() {
+        int negativeRoomNumber = -1;
+        assertThrows(AssertionError.class, () ->
+                new EditTaskCommand(negativeRoomNumber, VALID_TASK_INDEX_ONE, descriptor));
     }
 
     @Test
@@ -34,6 +69,134 @@ public class EditTaskCommandTest {
     public void constructor_nullEditTaskDescriptor_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () ->
                 new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE, null));
+    }
+
+    @Test
+    public void execute_getRoomWithRoomNumberReturnsNull_throwsAssertionError() {
+        when(modelMock.getRoomWithRoomNumber(anyInt())).thenReturn(null);
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(RESTOCK_SUPPLY));
+
+        EditTaskCommand editTaskCommand = new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN,
+                VALID_TASK_INDEX_ONE, descriptor);
+
+        assertThrows(AssertionError.class, () -> editTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_getTaskFromRoomWithTaskIndexReturnsNull_throwsAssertionError() {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom)).thenReturn(null);
+
+        EditTaskCommand editTaskCommand = new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN,
+                VALID_TASK_INDEX_ONE, descriptor);
+
+        assertThrows(AssertionError.class, () -> editTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_roomWithRoomNumberNotInModel_throwsCommandException() {
+        when(modelMock.getRoomWithRoomNumber(anyInt())).thenReturn(Optional.empty());
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(RESTOCK_SUPPLY));
+
+        EditTaskCommand editTaskCommand = new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN,
+                VALID_TASK_INDEX_ONE, descriptor);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_ROOM_NUMBER, () ->
+                editTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_taskWithTaskIndexNotInRoom_throwsCommandException() {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.empty());
+
+        EditTaskCommand editTaskCommand = new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN,
+                VALID_TASK_INDEX_ONE, descriptor);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_TASK_INDEX, () ->
+                editTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_taskDescriptorHasSameFieldsAsTask_throwsCommandException() {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(RESTOCK_SUPPLY));
+
+        descriptor.setDescription(RESTOCK_SUPPLY.getDescription());
+        descriptor.setDateTimeDue(RESTOCK_SUPPLY.getDueAt());
+
+        EditTaskCommand editTaskCommand = new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN,
+                VALID_TASK_INDEX_ONE, descriptor);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_TASK_NOT_EDITED, () ->
+                editTaskCommand.execute(modelMock));
+    }
+
+    @Test
+    public void execute_taskDescriptorHasDifferentDescription_editSuccessful() throws Exception {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(REMIND_PATIENT));
+
+        descriptor.setDescription(new Description(VALID_DESCRIPTION_ORDER_BEDSHEET));
+        descriptor.setDateTimeDue(REMIND_PATIENT.getDueAt());
+
+        Task editedTask = new TaskBuilder()
+                .withDescription(VALID_DESCRIPTION_ORDER_BEDSHEET)
+                .withDateTimeDue(Optional.of(VALID_DATETIME_DUE_REMIND_PATIENT)).build();
+
+        CommandResult commandResult = new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE, descriptor)
+                .execute(modelMock);
+
+        verify(modelMock).setTaskToRoom(REMIND_PATIENT, editedTask, validRoom);
+        assertEquals(String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, VALID_TASK_INDEX_ONE.getOneBased(),
+                VALID_ROOM_NUMBER_SEVEN, editedTask), commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_taskDescriptionHasDifferentDateTimeDue_editSuccessful() throws Exception {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(REMIND_PATIENT));
+
+        descriptor.setDescription(REMIND_PATIENT.getDescription());
+        descriptor.setDateTimeDue(new DateTimeDue(VALID_DATETIME_DUE_ORDER_BEDSHEET));
+
+        Task editedTask = new TaskBuilder()
+                .withDescription(VALID_DESCRIPTION_REMIND_PATIENT)
+                .withDateTimeDue(Optional.of(VALID_DATETIME_DUE_ORDER_BEDSHEET)).build();
+
+        CommandResult commandResult = new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE, descriptor)
+                .execute(modelMock);
+
+        verify(modelMock).setTaskToRoom(REMIND_PATIENT, editedTask, validRoom);
+        assertEquals(String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, VALID_TASK_INDEX_ONE.getOneBased(),
+                VALID_ROOM_NUMBER_SEVEN, editedTask), commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_taskDescriptionHasAllDifferentFields_editSuccessful() throws Exception {
+        when(modelMock.getRoomWithRoomNumber(VALID_ROOM_NUMBER_SEVEN)).thenReturn(Optional.of(validRoom));
+        when(modelMock.getTaskFromRoomWithTaskIndex(VALID_TASK_INDEX_ONE, validRoom))
+                .thenReturn(Optional.of(REMIND_PATIENT));
+
+        descriptor.setDescription(new Description(VALID_DESCRIPTION_ORDER_BEDSHEET));
+        descriptor.setDateTimeDue(new DateTimeDue(VALID_DATETIME_DUE_ORDER_BEDSHEET));
+
+        Task editedTask = new TaskBuilder()
+                .withDescription(VALID_DESCRIPTION_ORDER_BEDSHEET)
+                .withDateTimeDue(Optional.of(VALID_DATETIME_DUE_ORDER_BEDSHEET)).build();
+
+        CommandResult commandResult = new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE, descriptor)
+                .execute(modelMock);
+
+        verify(modelMock).setTaskToRoom(REMIND_PATIENT, editedTask, validRoom);
+        assertEquals(String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, VALID_TASK_INDEX_ONE.getOneBased(),
+                VALID_ROOM_NUMBER_SEVEN, editedTask), commandResult.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -76,28 +76,29 @@ public class ParserUtilTest {
         assertEquals(VALID_TASK_INDEX_ONE, ParserUtil.parseTaskIndex("  1  "));
     }
 
+    //@@author w-yeehong
     @Test
     public void arePrefixesPresent() {
         Prefix prefixOnePresent = mock(Prefix.class);
         Prefix prefixTwoPresent = mock(Prefix.class);
         Prefix prefixThreeMissing = mock(Prefix.class);
 
-        ArgumentMultimap argMultimap = mock(ArgumentMultimap.class);
-        when(argMultimap.getValue(prefixOnePresent)).thenReturn(Optional.of("one"));
-        when(argMultimap.getValue(prefixTwoPresent)).thenReturn(Optional.of("two"));
-        when(argMultimap.getValue(prefixThreeMissing)).thenReturn(Optional.empty());
+        ArgumentMultimap argMultimapMock = mock(ArgumentMultimap.class);
+        when(argMultimapMock.getValue(prefixOnePresent)).thenReturn(Optional.of("one"));
+        when(argMultimapMock.getValue(prefixTwoPresent)).thenReturn(Optional.of("two"));
+        when(argMultimapMock.getValue(prefixThreeMissing)).thenReturn(Optional.empty());
 
         // One missing prefix - returns false
-        assertFalse(ParserUtil.arePrefixesPresent(argMultimap, prefixThreeMissing));
+        assertFalse(ParserUtil.arePrefixesPresent(argMultimapMock, prefixThreeMissing));
 
         // One present and one missing prefixes - returns false
-        assertFalse(ParserUtil.arePrefixesPresent(argMultimap, prefixOnePresent, prefixThreeMissing));
+        assertFalse(ParserUtil.arePrefixesPresent(argMultimapMock, prefixOnePresent, prefixThreeMissing));
 
         // No prefixes - returns true
-        assertTrue(ParserUtil.arePrefixesPresent(argMultimap));
+        assertTrue(ParserUtil.arePrefixesPresent(argMultimapMock));
 
         // Two present prefixes - returns true
-        assertTrue(ParserUtil.arePrefixesPresent(argMultimap, prefixOnePresent, prefixTwoPresent));
+        assertTrue(ParserUtil.arePrefixesPresent(argMultimapMock, prefixOnePresent, prefixTwoPresent));
     }
 
     @Test
@@ -106,25 +107,26 @@ public class ParserUtilTest {
         Prefix prefixTwoPresent = mock(Prefix.class);
         Prefix prefixThreeMissing = mock(Prefix.class);
 
-        ArgumentMultimap argMultimap = mock(ArgumentMultimap.class);
-        when(argMultimap.getValue(prefixOnePresent)).thenReturn(Optional.of("one"));
-        when(argMultimap.getValue(prefixTwoPresent)).thenReturn(Optional.of("two"));
-        when(argMultimap.getValue(prefixThreeMissing)).thenReturn(Optional.empty());
+        ArgumentMultimap argMultimapMock = mock(ArgumentMultimap.class);
+        when(argMultimapMock.getValue(prefixOnePresent)).thenReturn(Optional.of("one"));
+        when(argMultimapMock.getValue(prefixTwoPresent)).thenReturn(Optional.of("two"));
+        when(argMultimapMock.getValue(prefixThreeMissing)).thenReturn(Optional.empty());
 
         // No prefixes - returns false
-        assertFalse(ParserUtil.isExactlyOnePrefixPresent(argMultimap));
+        assertFalse(ParserUtil.isExactlyOnePrefixPresent(argMultimapMock));
 
         // Two present prefixes - returns false
-        assertFalse(ParserUtil.isExactlyOnePrefixPresent(argMultimap, prefixOnePresent, prefixTwoPresent));
+        assertFalse(ParserUtil.isExactlyOnePrefixPresent(argMultimapMock, prefixOnePresent, prefixTwoPresent));
 
         // Two present and one missing prefixes - returns false
-        assertFalse(ParserUtil.isExactlyOnePrefixPresent(argMultimap,
+        assertFalse(ParserUtil.isExactlyOnePrefixPresent(argMultimapMock,
                 prefixOnePresent, prefixTwoPresent, prefixThreeMissing));
 
         // One present prefix - returns true
-        assertTrue(ParserUtil.isExactlyOnePrefixPresent(argMultimap, prefixOnePresent));
+        assertTrue(ParserUtil.isExactlyOnePrefixPresent(argMultimapMock, prefixOnePresent));
 
         // One present and one missing prefixes - returns true
-        assertTrue(ParserUtil.isExactlyOnePrefixPresent(argMultimap, prefixOnePresent, prefixThreeMissing));
+        assertTrue(ParserUtil.isExactlyOnePrefixPresent(argMultimapMock, prefixOnePresent, prefixThreeMissing));
     }
+    //@@author w-yeehong
 }

--- a/src/test/java/seedu/address/logic/parser/task/AddTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/AddTaskCommandParserTest.java
@@ -18,6 +18,8 @@ import static seedu.address.testutil.command.TaskCommandTestUtil.DESCRIPTION_DES
 import static seedu.address.testutil.command.TaskCommandTestUtil.DESCRIPTION_DESC_REMIND_PATIENT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DATETIME_DUE_FORMAT_DESC;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DATETIME_DUE_VALUE_DESC;
+import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DESCRIPTION_EMPTY_STRING_DESC;
+import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DESCRIPTION_EXCEED_LIMIT_DESC;
 
 import java.util.Optional;
 
@@ -27,6 +29,7 @@ import seedu.address.logic.commands.task.AddTaskCommand;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.room.RoomCliSyntax;
 import seedu.address.model.task.DateTimeDue;
+import seedu.address.model.task.Description;
 import seedu.address.model.task.Task;
 import seedu.address.testutil.TaskBuilder;
 
@@ -80,6 +83,14 @@ public class AddTaskCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+        // invalid description - empty description
+        assertParseFailure(parser, INVALID_DESCRIPTION_EMPTY_STRING_DESC + ROOM_NUMBER_DESC_ONE
+                + DATETIME_DUE_DESC_REMIND_PATIENT, Description.MESSAGE_CONSTRAINTS);
+
+        // invalid description - exceed character limit
+        assertParseFailure(parser, INVALID_DESCRIPTION_EXCEED_LIMIT_DESC + ROOM_NUMBER_DESC_ONE
+                + DATETIME_DUE_DESC_REMIND_PATIENT, Description.MESSAGE_CONSTRAINTS);
+
         // invalid due date value
         assertParseFailure(parser, DESCRIPTION_DESC_REMIND_PATIENT + ROOM_NUMBER_DESC_ONE
                 + INVALID_DATETIME_DUE_VALUE_DESC, DateTimeDue.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/task/EditTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/EditTaskCommandParserTest.java
@@ -11,6 +11,7 @@ import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_EIG
 import static seedu.address.testutil.command.RoomCommandTestUtil.ROOM_NUMBER_SEVEN_DESC;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_INDEX_ONE;
 import static seedu.address.testutil.command.RoomCommandTestUtil.VALID_ROOM_NUMBER_SEVEN;
+import static seedu.address.testutil.command.TaskCommandTestUtil.DATETIME_DUE_DESC_CLEAR_DATETIME;
 import static seedu.address.testutil.command.TaskCommandTestUtil.DATETIME_DUE_DESC_ORDER_BEDSHEETS;
 import static seedu.address.testutil.command.TaskCommandTestUtil.DATETIME_DUE_DESC_REMIND_PATIENT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.DESCRIPTION_DESC_ORDER_BEDSHEETS;
@@ -24,6 +25,8 @@ import static seedu.address.testutil.command.TaskCommandTestUtil.TASK_NUMBER_DES
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DATETIME_DUE_REMIND_PATIENT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DESCRIPTION_REMIND_PATIENT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_TASK_INDEX_ONE;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -68,6 +71,12 @@ public class EditTaskCommandParserTest {
         // multiple due dates - last due date accepted
         assertParseSuccess(parser, ROOM_NUMBER_SEVEN_DESC + TASK_NUMBER_DESC_ONE + DESCRIPTION_DESC_REMIND_PATIENT
                 + DATETIME_DUE_DESC_ORDER_BEDSHEETS + DATETIME_DUE_DESC_REMIND_PATIENT,
+                new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE, descriptor));
+
+        // due date is set to INPUT_REMOVE_DUE_DATE
+        descriptor.setDateTimeDue(new DateTimeDue(Optional.empty()));
+        assertParseSuccess(parser, ROOM_NUMBER_SEVEN_DESC + TASK_NUMBER_DESC_ONE
+                        + DESCRIPTION_DESC_REMIND_PATIENT + DATETIME_DUE_DESC_CLEAR_DATETIME,
                 new EditTaskCommand(VALID_ROOM_NUMBER_SEVEN, VALID_TASK_INDEX_ONE, descriptor));
     }
 

--- a/src/test/java/seedu/address/logic/parser/task/EditTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/EditTaskCommandParserTest.java
@@ -18,6 +18,8 @@ import static seedu.address.testutil.command.TaskCommandTestUtil.DESCRIPTION_DES
 import static seedu.address.testutil.command.TaskCommandTestUtil.DESCRIPTION_DESC_REMIND_PATIENT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DATETIME_DUE_FORMAT_DESC;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DATETIME_DUE_VALUE_DESC;
+import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DESCRIPTION_EMPTY_STRING_DESC;
+import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DESCRIPTION_EXCEED_LIMIT_DESC;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_TASK_NUMBER;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_TASK_NUMBER_DESC;
 import static seedu.address.testutil.command.TaskCommandTestUtil.TASK_NUMBER_DESC_ONE;
@@ -116,6 +118,16 @@ public class EditTaskCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+        // invalid description - empty description
+        assertParseFailure(parser, ROOM_NUMBER_SEVEN_DESC + TASK_NUMBER_DESC_ONE
+                + INVALID_DESCRIPTION_EMPTY_STRING_DESC + DATETIME_DUE_DESC_REMIND_PATIENT,
+                Description.MESSAGE_CONSTRAINTS);
+
+        // invalid description - exceed character limit
+        assertParseFailure(parser, ROOM_NUMBER_SEVEN_DESC + TASK_NUMBER_DESC_ONE
+                + INVALID_DESCRIPTION_EXCEED_LIMIT_DESC + DATETIME_DUE_DESC_REMIND_PATIENT,
+                Description.MESSAGE_CONSTRAINTS);
+
         // invalid due date value
         assertParseFailure(parser, ROOM_NUMBER_SEVEN_DESC + TASK_NUMBER_DESC_ONE + DESCRIPTION_DESC_REMIND_PATIENT
                 + INVALID_DATETIME_DUE_VALUE_DESC, DateTimeDue.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/task/TaskParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/TaskParserUtilTest.java
@@ -5,6 +5,8 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.command.GeneralCommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DATETIME_DUE_FORMAT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DATETIME_DUE_VALUE;
+import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DESCRIPTION_EMPTY_STRING;
+import static seedu.address.testutil.command.TaskCommandTestUtil.INVALID_DESCRIPTION_EXCEED_LIMIT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DATETIME_DUE_REMIND_PATIENT;
 import static seedu.address.testutil.command.TaskCommandTestUtil.VALID_DESCRIPTION_REMIND_PATIENT;
 
@@ -21,6 +23,15 @@ public class TaskParserUtilTest {
     @Test
     public void parseDescription_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> TaskParserUtil.parseDescription((String) null));
+    }
+
+    @Test
+    public void parseDescription_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () ->
+                TaskParserUtil.parseDescription(INVALID_DESCRIPTION_EMPTY_STRING)); // empty string
+
+        assertThrows(ParseException.class, () ->
+                TaskParserUtil.parseDescription(INVALID_DESCRIPTION_EXCEED_LIMIT)); // exceed character limit
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/command/TaskCommandTestUtil.java
+++ b/src/test/java/seedu/address/testutil/command/TaskCommandTestUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.task.TaskCliSyntax.PREFIX_TASK_NUMBER;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.parser.task.EditTaskCommandParser;
+import seedu.address.model.task.Description;
 
 public class TaskCommandTestUtil {
 
@@ -16,27 +17,33 @@ public class TaskCommandTestUtil {
     public static final Index VALID_TASK_INDEX_ONE = Index.fromOneBased(1);
     public static final Index VALID_TASK_INDEX_TWO = Index.fromOneBased(2);
 
+    public static final String INVALID_DESCRIPTION_EMPTY_STRING = "";
+    public static final String INVALID_DESCRIPTION_EXCEED_LIMIT = "a".repeat(Description.MAXIMUM_LENGTH + 1);
     public static final String INVALID_DATETIME_DUE_VALUE = "aaa";
     public static final String INVALID_DATETIME_DUE_FORMAT = "2020-12-31";
     public static final String INVALID_TASK_NUMBER = "-1";
 
     public static final String DESCRIPTION_DESC_REMIND_PATIENT = " " + PREFIX_DESCRIPTION
-        + VALID_DESCRIPTION_REMIND_PATIENT;
+            + VALID_DESCRIPTION_REMIND_PATIENT;
     public static final String DESCRIPTION_DESC_ORDER_BEDSHEETS = " " + PREFIX_DESCRIPTION
-        + VALID_DATETIME_DUE_ORDER_BEDSHEET;
+            + VALID_DATETIME_DUE_ORDER_BEDSHEET;
     public static final String DATETIME_DUE_DESC_REMIND_PATIENT = " " + PREFIX_DUE_DATE
-        + VALID_DATETIME_DUE_REMIND_PATIENT;
+            + VALID_DATETIME_DUE_REMIND_PATIENT;
     public static final String DATETIME_DUE_DESC_ORDER_BEDSHEETS = " " + PREFIX_DUE_DATE
-        + VALID_DATETIME_DUE_ORDER_BEDSHEET;
+            + VALID_DATETIME_DUE_ORDER_BEDSHEET;
     public static final String DATETIME_DUE_DESC_CLEAR_DATETIME = " " + PREFIX_DUE_DATE
             + EditTaskCommandParser.INPUT_REMOVE_DUE_DATE;
     public static final String TASK_NUMBER_DESC_ONE = " " + PREFIX_TASK_NUMBER + "1";
     public static final String TASK_NUMBER_DESC_TWO = " " + PREFIX_TASK_NUMBER + "2";
 
+    public static final String INVALID_DESCRIPTION_EMPTY_STRING_DESC = " " + PREFIX_DESCRIPTION
+            + INVALID_DESCRIPTION_EMPTY_STRING;
+    public static final String INVALID_DESCRIPTION_EXCEED_LIMIT_DESC = " " + PREFIX_DESCRIPTION
+            + INVALID_DESCRIPTION_EXCEED_LIMIT;
     public static final String INVALID_DATETIME_DUE_VALUE_DESC = " " + PREFIX_DUE_DATE
-        + INVALID_DATETIME_DUE_VALUE;
+            + INVALID_DATETIME_DUE_VALUE;
     public static final String INVALID_DATETIME_DUE_FORMAT_DESC = " " + PREFIX_DUE_DATE
-        + INVALID_DATETIME_DUE_FORMAT;
+            + INVALID_DATETIME_DUE_FORMAT;
     public static final String INVALID_TASK_NUMBER_DESC = " " + PREFIX_TASK_NUMBER
-        + INVALID_TASK_NUMBER;
+            + INVALID_TASK_NUMBER;
 }

--- a/src/test/java/seedu/address/testutil/command/TaskCommandTestUtil.java
+++ b/src/test/java/seedu/address/testutil/command/TaskCommandTestUtil.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.task.TaskCliSyntax.PREFIX_DUE_DATE;
 import static seedu.address.logic.parser.task.TaskCliSyntax.PREFIX_TASK_NUMBER;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.parser.task.EditTaskCommandParser;
 
 public class TaskCommandTestUtil {
 
@@ -27,6 +28,8 @@ public class TaskCommandTestUtil {
         + VALID_DATETIME_DUE_REMIND_PATIENT;
     public static final String DATETIME_DUE_DESC_ORDER_BEDSHEETS = " " + PREFIX_DUE_DATE
         + VALID_DATETIME_DUE_ORDER_BEDSHEET;
+    public static final String DATETIME_DUE_DESC_CLEAR_DATETIME = " " + PREFIX_DUE_DATE
+            + EditTaskCommandParser.INPUT_REMOVE_DUE_DATE;
     public static final String TASK_NUMBER_DESC_ONE = " " + PREFIX_TASK_NUMBER + "1";
     public static final String TASK_NUMBER_DESC_TWO = " " + PREFIX_TASK_NUMBER + "2";
 


### PR DESCRIPTION
Improve test coverage for the following classes:
1. `AddTaskCommand`
1. `DeleteTaskCommand`
1. `EditTaskCommand`
1. `TaskParserUtil`
1. `AddTaskCommandParser`
1. `EditTaskCommandParser`